### PR TITLE
Add container build for ghcr.io

### DIFF
--- a/.github/workflows/docker_deploy.yaml
+++ b/.github/workflows/docker_deploy.yaml
@@ -1,0 +1,49 @@
+#
+name: Create and publish a Docker image
+
+# Configures this workflow to run every time a change is pushed to the branch called `release`.
+on:
+  push:
+    branches: ['main']
+
+# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+# There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      #
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3.3.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5.7.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6.15.0
+        with:
+          context: .
+          file: devtools/containers/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Use the conda-forge base image with Python
+FROM mambaorg/micromamba:jammy
+
+LABEL org.opencontainers.image.source=https://github.com/OpenADMET/openadmet_models
+LABEL org.opencontainers.image.description="OpenADMET models"
+LABEL org.opencontainers.image.licenses=MIT
+
+# set environment variables
+ENV PYTHONUNBUFFERED 1
+
+RUN micromamba config append channels conda-forge
+
+COPY --chown=$MAMBA_USER:$MAMBA_USER  devtools/conda-envs/openadmet_models.yaml /tmp/env.yaml
+COPY --chown=$MAMBA_USER:$MAMBA_USER  .  /home/mambauser/openadmet_models
+
+RUN micromamba install -y -n base git -f /tmp/env.yaml && \
+    micromamba clean --all --yes
+
+ARG MAMBA_DOCKERFILE_ACTIVATE=1
+
+
+WORKDIR /home/mambauser
+
+RUN python -m pip install --no-deps -e openadmet_models

--- a/devtools/conda-envs/openadmet_models.yaml
+++ b/devtools/conda-envs/openadmet_models.yaml
@@ -14,6 +14,8 @@ dependencies:
   - intake
   - joblib
   - zarr >=3.0.0
+  - ipython
+  - jupyterlab
 
   - rdkit
   - molfeat

--- a/devtools/containers/Dockerfile
+++ b/devtools/containers/Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.description="OpenADMET models"
 LABEL org.opencontainers.image.licenses=MIT
 
 # set environment variables
-ENV PYTHONUNBUFFERED 1
+ENV PYTHONUNBUFFERED=1
 
 RUN micromamba config append channels conda-forge
 
@@ -15,10 +15,11 @@ COPY --chown=$MAMBA_USER:$MAMBA_USER  .  /home/mambauser/openadmet_models
 
 RUN micromamba install -y -n base git -f /tmp/env.yaml && \
     micromamba clean --all --yes
-
+    
 ARG MAMBA_DOCKERFILE_ACTIVATE=1
 
 
 WORKDIR /home/mambauser
 
 RUN python -m pip install --no-deps -e openadmet_models
+


### PR DESCRIPTION
Fixes #74 

Adds a container that contains repo and all dependencies so that we can build RT inference stack. 