### PR TITLE
Switch to default TabPFN rather than buggy TabPFN-extensions interface

### DIFF
--- a/openadmet/models/architecture/tabpfn.py
+++ b/openadmet/models/architecture/tabpfn.py
@@ -56,7 +56,7 @@ class TabPFNExtensionModelBase(PickleableModelBase):
         """
         if value not in ["cpu", "gpu", "auto"]:
             raise ValueError("Accelerator must be either 'cpu' or 'gpu' or 'auto'")
-        
+
         return value
 
 


### PR DESCRIPTION
## Description
Partial fix for #284, moving to the default TabPFN shipped with  the main repo, not the `tabpfn-extensions` interface. 

## Status
- [X] Ready to go
