### PR TITLE
Remove mod_params and add class level params from MTENN config

### DIFF
--- a/openadmet/models/architecture/mtenn.py
+++ b/openadmet/models/architecture/mtenn.py
@@ -5,7 +5,7 @@ from typing import ClassVar
 import torch
 from lightning import pytorch as pl
 from loguru import logger
-from mtenn.config import SchNetRepresentationConfig, ModelConfig
+from mtenn.config import ModelConfig, SchNetRepresentationConfig
 
 from openadmet.models.architecture.model_base import LightningModelBase
 from openadmet.models.architecture.model_base import models as model_registry
@@ -128,7 +128,7 @@ class MTENNLightningModule(pl.LightningModule):
 
     def configure_optimizers(self):
         """
-        Configure AdamW optimizer for training. This will eventually run through calling LightningModuleBase
+        Configure AdamW optimizer for training. This will eventually run through calling LightningModuleBase.
 
         Returns
         -------


### PR DESCRIPTION
## Description
The MTENN anvil architecture was originally coded to only take defaults of the SchNet Representation and for ModelConfig, both classes from the MTENN package. This PR will expose hyper param options to make training a model more flexible. Also, it will satisfy the removal of mod_params, which is a team plan moving forward.  

Will resolve #334 

## Todos
  - [x] Select params to expose and add at class level
  - [x] Rework build function to run with new setup
  - [x] Add docstrings while we are at it
  - [x] Update tests


