### PR TITLE
Set shuffle default in GAT featurizer to `False`

### DIFF
--- a/openadmet/models/features/gat_featurizer.py
+++ b/openadmet/models/features/gat_featurizer.py
@@ -32,7 +32,7 @@ class GATGraphFeaturizer(FeaturizerBase):
     """
 
     batch_size: int = 32
-    shuffle: bool = True
+    shuffle: bool = False
     num_workers: int = 0
 
     def _featurize_single_molecule(


### PR DESCRIPTION
## Description
GAT currently shuffles by default, causing issues per #383.

Resolves #384 

## Status
- [X] Ready to go


## Developers certificate of origin
- [X] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenADMET/openadmet_toolkit/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
