### PR TITLE
Create a warning if MTENN is being used with CPU

### DIFF
--- a/openadmet/models/architecture/mtenn.py
+++ b/openadmet/models/architecture/mtenn.py
@@ -251,7 +251,7 @@ class MTENNSchNetModel(LightningModelBase):
         Use the model for prediction.
 
         WARNING: Current MTENN issue where loading a model must be done on GPU to obtain the correct weights.
-        Set env variable OADMET_ALLOW_MTENN_CPU to either 1 or True to use CPU. 
+        Set env variable OADMET_ALLOW_MTENN_CPU to either 1 or True to use CPU.
 
         Parameters
         ----------


### PR DESCRIPTION
## Description
Closes #376 

There is an issue with MTENN when you load weights trained with GPU into a CPU. 
This warning message ensures users know this error exists and that if they are loading a model by hand and predicting they must use the same device they trained with. 

