### PR TITLE
Load in best weights after training

### DIFF
--- a/openadmet/models/trainer/lightning.py
+++ b/openadmet/models/trainer/lightning.py
@@ -184,7 +184,7 @@ class LightningTrainer(TrainerBase):
 
         # Load best checkpoint after training
         checkpoint = torch.load(
-            self._callbacks["ModelCheckpoint"].best_model_path, weights_only=True
+            self._callbacks["ModelCheckpoint"].best_model_path, weights_only=False
         )
         self.model.estimator.load_state_dict(checkpoint["state_dict"])
 


### PR DESCRIPTION
## Description
Instead of saving most recent weights, we can save best weights realized during training.

## Status
- [X] Ready to go

## Developers certificate of origin
- [X] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenADMET/openadmet_toolkit/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
