### PR TITLE
Modify checkpoint load for best model as a try-except statement

### DIFF
--- a/openadmet/models/trainer/lightning.py
+++ b/openadmet/models/trainer/lightning.py
@@ -191,7 +191,9 @@ class LightningTrainer(TrainerBase):
 
             self.model.estimator.load_state_dict(checkpoint["state_dict"])
         except:
-            logger.debug("Warning: Training did not generate a best checkpoint. Using the latest checkpoint state-dict for evaluation.")
+            logger.debug(
+                "Warning: Training did not generate a best checkpoint. Using the latest checkpoint state-dict for evaluation."
+            )
             pass
 
         return self.model


### PR DESCRIPTION
## Description
Currently the following line in lightning.py must be executed. 

```
 # Load best checkpoint after training
        checkpoint = torch.load(
            self._callbacks["ModelCheckpoint"].best_model_path, weights_only=False
        )
```

It is best practice to use the best model path. However, if there is a situation where the best checkpoint is not being created, this will cause the job to fail post training. The solution is adding a try-except statement, with a warning for when only latest is present.

Closes issue #415 
