### PR TITLE
Pass MTENN GPU integration test

### DIFF
--- a/openadmet/models/architecture/mtenn.py
+++ b/openadmet/models/architecture/mtenn.py
@@ -125,7 +125,7 @@ class MTENNLightningModule(pl.LightningModule):
 
         """
         data_batch, _ = batch
-        #Handle (n,1) shape required for anvil workflow 
+        # Handle (n,1) shape required for anvil workflow
         preds = [self(data).unsqueeze(1) for data in data_batch]
         return torch.cat(preds)
 


### PR DESCRIPTION
## Description
GPU integration test for mtenn was failing. I believe this was due to a shape mismatch during the prediction step. This arose after change in API from mtenn, and I had not caught it for the main branch yet. 