### PR TITLE
Add protocol to external link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 The library includes traditional machine learning methods, deep learning models, and active learning workflows. It is designed for general-purpose use and is not intended to implement every state-of-the-art architectures, but rather to provide a practical, flexible foundation for ADMET modeling.
 
-Read the documentation [here](https://docs.openadmet.org) to learn more. There is also a set of [demonstration tutorials](demos.openadmet.org) for a deeper dive into and a showcase example you can try live on [Google Colab](try.openadmet.org)!
+Read the documentation [here](https://docs.openadmet.org) to learn more. There is also a set of [demonstration tutorials](https://demos.openadmet.org) for a deeper dive into and a showcase example you can try live on [Google Colab](https://try.openadmet.org)!
 
 ## License
 


### PR DESCRIPTION
## Description
Added missing protocol to external links in README.md to ensure they open correctly instead of navigating to an invalid path within the repository.

https://github.com/user-attachments/assets/cdf36cdb-148a-4656-9b27-1beead65b266

## Status
- [x] Ready to go


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenADMET/openadmet_toolkit/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
