### PR TITLE
Fix TabPFN GPU CI integration tests

### DIFF
--- a/openadmet/models/tests/integration/test_data/tabpfn.yaml
+++ b/openadmet/models/tests/integration/test_data/tabpfn.yaml
@@ -30,6 +30,12 @@ procedure:
     params:
       descr_type: desc2d
 
+  transform:
+    # Using the ImputeTransform to handle missing values
+    type: ImputeTransform
+    params:
+      strategy: mean  # or median, most_frequent, etc.
+
   model:
     type: TabPFNRegressorModel
     params:


### PR DESCRIPTION
## Description
Fixes a `NaN` feature issue in GPU CI by adding the `Impute` transform

## Status
- [X] Ready to go


## Developers certificate of origin
- [X] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenADMET/openadmet_toolkit/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
