### PR TITLE
Add CONDA_OVERRIDE_CUDA environment variable to Dockerfile

### DIFF
--- a/devtools/containers/Dockerfile
+++ b/devtools/containers/Dockerfile
@@ -7,6 +7,7 @@ LABEL org.opencontainers.image.licenses=MIT
 
 # set environment variables
 ENV PYTHONUNBUFFERED=1
+ENV CONDA_OVERRIDE_CUDA="11.8"
 
 RUN micromamba config append channels conda-forge
 


### PR DESCRIPTION
## Description
Add override for GPU build

## Status
- [X] Ready to go


## Developers certificate of origin
- [X] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenADMET/openadmet_toolkit/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
