### PR TITLE
Add ability to load in pretraining weights for finetuning in chemprop

### DIFF
--- a/devtools/conda-envs/openadmet-models-gpu.yaml
+++ b/devtools/conda-envs/openadmet-models-gpu.yaml
@@ -58,3 +58,4 @@ dependencies:
     - git+https://github.com/JacksonBurns/neural-pairwise-regression.git
     - git+https://github.com/OpenADMET/molfeat.git@main
     - git+https://github.com/PatWalters/useful_rdkit_utils.git@master
+    - git+https://github.com/JacksonBurns/chemeleon.git@main


### PR DESCRIPTION
We want to be able to load weights from pretraining from external sources.

This PR will affect only chemprop, but maybe this could eventually be extended to other foundation models.
