### PR TITLE
Fix three bugs in comparison/posthoc.py

### DIFF
--- a/openadmet/models/comparison/posthoc.py
+++ b/openadmet/models/comparison/posthoc.py
@@ -752,15 +752,19 @@ class PostHocComparison(ComparisonBase):
             if reverse_cmap:
                 cmap = cmap + "_r"
 
-            significance = pd.DataFrame(hsd.pvalue)
-            significance[(hsd.pvalue < self.sig_levels[2]) & (hsd.pvalue >= 0)] = "***"
-            significance[
-                (hsd.pvalue < self.sig_levels[1]) & (hsd.pvalue >= self.sig_levels[2])
-            ] = "**"
-            significance[
-                (hsd.pvalue < self.sig_levels[0]) & (hsd.pvalue >= self.sig_levels[1])
-            ] = "*"
-            significance[(hsd.pvalue >= self.sig_levels[0])] = ""
+            significance = pd.DataFrame(
+                np.select(
+                    [
+                        (hsd.pvalue < self.sig_levels[2]) & (hsd.pvalue >= 0),
+                        (hsd.pvalue < self.sig_levels[1])
+                        & (hsd.pvalue >= self.sig_levels[2]),
+                        (hsd.pvalue < self.sig_levels[0])
+                        & (hsd.pvalue >= self.sig_levels[1]),
+                    ],
+                    ["***", "**", "*"],
+                    default="",
+                )
+            )
 
             # Create a DataFrame for the annotations
             annotations = (


### PR DESCRIPTION
## Description

Fix three bugs in `openadmet/models/comparison/posthoc.py`:

1. **AttributeError on `int.copy()`** (line ~314): `ind` from `enumerate()` is an `int`, which has no `.copy()` method. This crashes when processing multitask models with `mt_id`. Fixed by removing the unnecessary `.copy()` call.

2. **Stray debug `print("here")`** (line ~406): Debug print statement left in production code before a `raise ValueError`. Removed.

3. **FutureWarning: float64 to string cast** (line ~747): Direct assignment of string `'***'` into a float64 DataFrame column triggers `FutureWarning` in pandas and will break in future versions. Fixed using `np.select()` for type-safe conditional assignment.

## Status
- [X] Ready to go

## Developers certificate of origin
- [X] I certify that this contribution is covered by the [License](LICENSE) and the Developer Certificate of Origin at https://developercertificate.org/