### PR TITLE
Add RAE and fraction-within-1-log regression metrics

### DIFF
--- a/openadmet/models/eval/cross_validation.py
+++ b/openadmet/models/eval/cross_validation.py
@@ -1,6 +1,7 @@
 """Cross-validation evaluators for regression models."""
 
 import json
+from functools import partial
 from collections import defaultdict
 from typing import Any, ClassVar
 import pandas as pd
@@ -509,6 +510,18 @@ class PytorchLightningRepeatedKFoldCrossValidation(CrossValidationBase):
     min_val: float = Field(None, description="Minimum value for the axes")
     max_val: float = Field(None, description="Maximum value for the axes")
     use_wandb: bool = Field(False, description="Whether to use wandb")
+
+    @property
+    def active_metrics(self):
+        """Return metrics applicable to Lightning CV using raw metric callables."""
+        metrics = dict(self._metrics)
+        if self.pXC50:
+            metrics["pct_within_1_log"] = (
+                partial(pct_within_1_log_unit, pXC50=True),
+                False,
+                "Fraction within ±1 log",
+            )
+        return metrics
 
     def evaluate(
         self,

--- a/openadmet/models/eval/cross_validation.py
+++ b/openadmet/models/eval/cross_validation.py
@@ -151,7 +151,7 @@ class CrossValidationBase(EvalBase):
         metrics = dict(self._metrics)
         if self.pXC50:
             metrics["pct_within_1_log"] = (
-                make_scorer(pct_within_1_log_unit, pXC50=True),
+                make_scorer(pct_within_1_log_unit),
                 False,
                 "Fraction within ±1 log",
             )
@@ -517,7 +517,7 @@ class PytorchLightningRepeatedKFoldCrossValidation(CrossValidationBase):
         metrics = dict(self._metrics)
         if self.pXC50:
             metrics["pct_within_1_log"] = (
-                partial(pct_within_1_log_unit, pXC50=True),
+                pct_within_1_log_unit,
                 False,
                 "Fraction within ±1 log",
             )

--- a/openadmet/models/eval/cross_validation.py
+++ b/openadmet/models/eval/cross_validation.py
@@ -140,14 +140,21 @@ class CrossValidationBase(EvalBase):
             False,
             "RAE",
         ),
-        "pct_within_1_log": (
-            make_scorer(pct_within_1_log_unit),
-            False,
-            "Fraction within ±1 log",
-        ),
     }
     min_val: float = Field(None, description="Minimum value for the axes")
     max_val: float = Field(None, description="Maximum value for the axes")
+
+    @property
+    def active_metrics(self):
+        """Return metrics applicable to the current target scale."""
+        metrics = dict(self._metrics)
+        if self.pXC50:
+            metrics["pct_within_1_log"] = (
+                make_scorer(pct_within_1_log_unit, pXC50=True),
+                False,
+                "Fraction within ±1 log",
+            )
+        return metrics
 
     @property
     def metric_names(self):
@@ -160,7 +167,7 @@ class CrossValidationBase(EvalBase):
             List of metric names.
 
         """
-        return list(self._metrics.keys())
+        return list(self.active_metrics.keys())
 
 
 @evaluators.register("SKLearnRepeatedKFoldCrossValidation")
@@ -250,7 +257,7 @@ class SKLearnRepeatedKFoldCrossValidation(CrossValidationBase):
             y_true = y_true.to_numpy()
 
         # store the metric names and callables in dict suitable for sklearn cross_validate
-        self.sklearn_metrics = {k: v[0] for k, v in self._metrics.items()}
+        self.sklearn_metrics = {k: v[0] for k, v in self.active_metrics.items()}
 
         logger.info("Starting cross-validation")
 
@@ -366,7 +373,7 @@ class SKLearnRepeatedKFoldCrossValidation(CrossValidationBase):
             data=self.data,
             task_name=t_label,
             metric_names=self.metric_names,
-            metrics=self._metrics,
+            metrics=self.active_metrics,
             confidence_level=self.confidence_level,
             cv=True,
         )
@@ -394,7 +401,7 @@ class SKLearnRepeatedKFoldCrossValidation(CrossValidationBase):
             data=self.data,
             task_name=t_label,
             metric_names=self.metric_names,
-            metrics=self._metrics,
+            metrics=self.active_metrics,
             confidence_level=self.confidence_level,
             cv=True,
         )
@@ -497,11 +504,6 @@ class PytorchLightningRepeatedKFoldCrossValidation(CrossValidationBase):
         "ktau": (wrap_ktau, True, "Kendall's $\\tau$"),
         "spearmanr": (wrap_spearmanr, True, "Spearman's $\\rho$"),
         "rae": (relative_absolute_error, False, "RAE"),
-        "pct_within_1_log": (
-            pct_within_1_log_unit,
-            False,
-            "Fraction within ±1 log",
-        ),
     }
 
     min_val: float = Field(None, description="Minimum value for the axes")
@@ -591,7 +593,7 @@ class PytorchLightningRepeatedKFoldCrossValidation(CrossValidationBase):
             self.use_wandb = use_wandb
 
         # store the metric names and callables in dict suitable for sklearn cross_validate
-        self.sklearn_metrics = {k: v[0] for k, v in self._metrics.items()}
+        self.sklearn_metrics = {k: v[0] for k, v in self.active_metrics.items()}
 
         if groups is None:
             groups = np.array([i for i in range(X_all.shape[0])])
@@ -680,7 +682,7 @@ class PytorchLightningRepeatedKFoldCrossValidation(CrossValidationBase):
                 )
                 t_label = target_labels[task_id]
 
-                for metric_name, metric_data in self._metrics.items():
+                for metric_name, metric_data in self.active_metrics.items():
                     metric_func, is_scipy_metric, _ = metric_data
                     value = metric_func(t_true, t_pred)
                     self._metric_data[t_label][metric_name].append(value)
@@ -816,7 +818,7 @@ class PytorchLightningRepeatedKFoldCrossValidation(CrossValidationBase):
             data=self.data,
             task_name=t_label,
             metric_names=self.metric_names,
-            metrics=self._metrics,
+            metrics=self.active_metrics,
             confidence_level=self.confidence_level,
             cv=True,
         )
@@ -840,7 +842,7 @@ class PytorchLightningRepeatedKFoldCrossValidation(CrossValidationBase):
             data=self.data,
             task_name=t_label,
             metric_names=self.metric_names,
-            metrics=self._metrics,
+            metrics=self.active_metrics,
             confidence_level=self.confidence_level,
             cv=True,
         )

--- a/openadmet/models/eval/cross_validation.py
+++ b/openadmet/models/eval/cross_validation.py
@@ -21,6 +21,8 @@ from openadmet.models.eval.regression import (
     RegressionPlots,
     nan_omit_ktau,
     nan_omit_spearmanr,
+    pct_within_1_log_unit,
+    relative_absolute_error,
 )
 from openadmet.models.trainer.lightning import LightningTrainer
 from openadmet.models.eval.utils import _make_stat_caption, _make_stat_dict
@@ -133,6 +135,8 @@ class CrossValidationBase(EvalBase):
         "r2": (make_scorer(r2_score), False, "$R^2$"),
         "ktau": (make_scorer(wrap_ktau), True, "Kendall's $\\tau$"),
         "spearmanr": (make_scorer(wrap_spearmanr), True, "Spearman's $\\rho$"),
+        "rae": (make_scorer(relative_absolute_error), False, "RAE"),
+        "pct_within_1_log": (make_scorer(pct_within_1_log_unit), False, "% within ±1 log"),
     }
     min_val: float = Field(None, description="Minimum value for the axes")
     max_val: float = Field(None, description="Maximum value for the axes")
@@ -484,6 +488,8 @@ class PytorchLightningRepeatedKFoldCrossValidation(CrossValidationBase):
         "r2": (r2_score, False, "$R^2$"),
         "ktau": (wrap_ktau, True, "Kendall's $\\tau$"),
         "spearmanr": (wrap_spearmanr, True, "Spearman's $\\rho$"),
+        "rae": (relative_absolute_error, False, "RAE"),
+        "pct_within_1_log": (pct_within_1_log_unit, False, "% within ±1 log"),
     }
 
     min_val: float = Field(None, description="Minimum value for the axes")

--- a/openadmet/models/eval/cross_validation.py
+++ b/openadmet/models/eval/cross_validation.py
@@ -135,8 +135,16 @@ class CrossValidationBase(EvalBase):
         "r2": (make_scorer(r2_score), False, "$R^2$"),
         "ktau": (make_scorer(wrap_ktau), True, "Kendall's $\\tau$"),
         "spearmanr": (make_scorer(wrap_spearmanr), True, "Spearman's $\\rho$"),
-        "rae": (make_scorer(relative_absolute_error), False, "RAE"),
-        "pct_within_1_log": (make_scorer(pct_within_1_log_unit), False, "% within ±1 log"),
+        "rae": (
+            make_scorer(relative_absolute_error, greater_is_better=False),
+            False,
+            "RAE",
+        ),
+        "pct_within_1_log": (
+            make_scorer(pct_within_1_log_unit),
+            False,
+            "Fraction within ±1 log",
+        ),
     }
     min_val: float = Field(None, description="Minimum value for the axes")
     max_val: float = Field(None, description="Maximum value for the axes")
@@ -489,7 +497,11 @@ class PytorchLightningRepeatedKFoldCrossValidation(CrossValidationBase):
         "ktau": (wrap_ktau, True, "Kendall's $\\tau$"),
         "spearmanr": (wrap_spearmanr, True, "Spearman's $\\rho$"),
         "rae": (relative_absolute_error, False, "RAE"),
-        "pct_within_1_log": (pct_within_1_log_unit, False, "% within ±1 log"),
+        "pct_within_1_log": (
+            pct_within_1_log_unit,
+            False,
+            "Fraction within ±1 log",
+        ),
     }
 
     min_val: float = Field(None, description="Minimum value for the axes")

--- a/openadmet/models/eval/regression.py
+++ b/openadmet/models/eval/regression.py
@@ -24,6 +24,58 @@ nan_omit_ktau = partial(kendalltau, nan_policy="omit")
 nan_omit_spearmanr = partial(spearmanr, nan_policy="omit")
 
 
+def relative_absolute_error(y_true, y_pred):
+    """
+    Compute Relative Absolute Error (RAE).
+
+    RAE = sum(|y_true - y_pred|) / sum(|y_true - mean(y_true)|).
+    Lower is better; RAE < 1.0 means the model outperforms a naive
+    mean predictor.
+
+    Parameters
+    ----------
+    y_true : array-like
+        True values.
+    y_pred : array-like
+        Predicted values.
+
+    Returns
+    -------
+    float
+        Relative absolute error.
+
+    """
+    y_true = np.asarray(y_true)
+    y_pred = np.asarray(y_pred)
+    numerator = np.sum(np.abs(y_true - y_pred))
+    denominator = np.sum(np.abs(y_true - np.mean(y_true)))
+    if denominator == 0:
+        return 0.0
+    return numerator / denominator
+
+
+def pct_within_1_log_unit(y_true, y_pred):
+    """
+    Compute the percentage of predictions within +/-1 log unit of the true value.
+
+    Parameters
+    ----------
+    y_true : array-like
+        True values (assumed to be on a log scale, e.g. pXC50).
+    y_pred : array-like
+        Predicted values.
+
+    Returns
+    -------
+    float
+        Fraction (0-1) of predictions within 1 log unit.
+
+    """
+    y_true = np.asarray(y_true)
+    y_pred = np.asarray(y_pred)
+    return np.mean(np.abs(y_true - y_pred) <= 1.0)
+
+
 @evaluators.register("RegressionMetrics")
 class RegressionMetrics(EvalBase):
     """
@@ -54,6 +106,8 @@ class RegressionMetrics(EvalBase):
         "r2": (r2_score, False, "$R^2$"),
         "ktau": (nan_omit_ktau, True, "Kendall's $\\tau$"),
         "spearmanr": (nan_omit_spearmanr, True, "Spearman's $\\rho$"),
+        "rae": (relative_absolute_error, False, "RAE"),
+        "pct_within_1_log": (pct_within_1_log_unit, False, "% within ±1 log"),
     }
 
     def evaluate(

--- a/openadmet/models/eval/regression.py
+++ b/openadmet/models/eval/regression.py
@@ -54,7 +54,7 @@ def relative_absolute_error(y_true, y_pred):
     return numerator / denominator
 
 
-def pct_within_1_log_unit(y_true, y_pred):
+def pct_within_1_log_unit(y_true, y_pred, pXC50=False):
     """
     Compute the fraction of predictions within +/-1 log unit of the true value.
 
@@ -64,6 +64,8 @@ def pct_within_1_log_unit(y_true, y_pred):
         True values (assumed to be on a log scale, e.g. pXC50).
     y_pred : array-like
         Predicted values.
+    pXC50 : bool, optional
+        Whether the target is in pXC50/log units.
 
     Returns
     -------
@@ -71,6 +73,9 @@ def pct_within_1_log_unit(y_true, y_pred):
         Fraction (0-1) of predictions within 1 log unit.
 
     """
+    if not pXC50:
+        raise ValueError("pct_within_1_log_unit is only valid when pXC50=True")
+
     y_true = np.asarray(y_true)
     y_pred = np.asarray(y_pred)
     return np.mean(np.abs(y_true - y_pred) <= 1.0)
@@ -98,6 +103,10 @@ class RegressionMetrics(EvalBase):
         0.95, description="Confidence level for the bootstrap"
     )
     use_wandb: bool = Field(False, description="Whether to use wandb")
+    pXC50: bool = Field(
+        False,
+        description="Whether targets are in pXC50/log units for log-based metrics",
+    )
     _evaluated: bool = False
 
     _metrics: dict = {
@@ -107,12 +116,19 @@ class RegressionMetrics(EvalBase):
         "ktau": (nan_omit_ktau, True, "Kendall's $\\tau$"),
         "spearmanr": (nan_omit_spearmanr, True, "Spearman's $\\rho$"),
         "rae": (relative_absolute_error, False, "RAE"),
-        "pct_within_1_log": (
-            pct_within_1_log_unit,
-            False,
-            "Fraction within ±1 log",
-        ),
     }
+
+    @property
+    def active_metrics(self):
+        """Return metrics applicable to the current target scale."""
+        metrics = dict(self._metrics)
+        if self.pXC50:
+            metrics["pct_within_1_log"] = (
+                partial(pct_within_1_log_unit, pXC50=True),
+                False,
+                "Fraction within ±1 log",
+            )
+        return metrics
 
     def evaluate(
         self,
@@ -176,7 +192,7 @@ class RegressionMetrics(EvalBase):
 
             self.data[t_label] = {}
 
-            for metric_tag, (metric, is_scipy, _) in self._metrics.items():
+            for metric_tag, (metric, is_scipy, _) in self.active_metrics.items():
                 value, lower_ci, upper_ci = self.stat_and_bootstrap(
                     metric_tag,
                     t_pred,
@@ -230,7 +246,7 @@ class RegressionMetrics(EvalBase):
             List of metric names.
 
         """
-        return list(self._metrics.keys())
+        return list(self.active_metrics.keys())
 
     @property
     def task_names(self):
@@ -312,7 +328,7 @@ class RegressionMetrics(EvalBase):
             data=self.data,
             task_name=t_label,
             metric_names=self.metric_names,
-            metrics=self._metrics,
+            metrics=self.active_metrics,
             confidence_level=self.bootstrap_confidence_level,
             cv=False,
         )

--- a/openadmet/models/eval/regression.py
+++ b/openadmet/models/eval/regression.py
@@ -50,11 +50,11 @@ def relative_absolute_error(y_true, y_pred):
     numerator = np.sum(np.abs(y_true - y_pred))
     denominator = np.sum(np.abs(y_true - np.mean(y_true)))
     if denominator == 0:
-        return 0.0
+        return np.nan
     return numerator / denominator
 
 
-def pct_within_1_log_unit(y_true, y_pred, pXC50=False):
+def pct_within_1_log_unit(y_true, y_pred):
     """
     Compute the fraction of predictions within +/-1 log unit of the true value.
 
@@ -64,8 +64,6 @@ def pct_within_1_log_unit(y_true, y_pred, pXC50=False):
         True values (assumed to be on a log scale, e.g. pXC50).
     y_pred : array-like
         Predicted values.
-    pXC50 : bool, optional
-        Whether the target is in pXC50/log units.
 
     Returns
     -------
@@ -73,9 +71,6 @@ def pct_within_1_log_unit(y_true, y_pred, pXC50=False):
         Fraction (0-1) of predictions within 1 log unit.
 
     """
-    if not pXC50:
-        raise ValueError("pct_within_1_log_unit is only valid when pXC50=True")
-
     y_true = np.asarray(y_true)
     y_pred = np.asarray(y_pred)
     return np.mean(np.abs(y_true - y_pred) <= 1.0)
@@ -124,7 +119,7 @@ class RegressionMetrics(EvalBase):
         metrics = dict(self._metrics)
         if self.pXC50:
             metrics["pct_within_1_log"] = (
-                partial(pct_within_1_log_unit, pXC50=True),
+                pct_within_1_log_unit,
                 False,
                 "Fraction within ±1 log",
             )

--- a/openadmet/models/eval/regression.py
+++ b/openadmet/models/eval/regression.py
@@ -56,7 +56,7 @@ def relative_absolute_error(y_true, y_pred):
 
 def pct_within_1_log_unit(y_true, y_pred):
     """
-    Compute the percentage of predictions within +/-1 log unit of the true value.
+    Compute the fraction of predictions within +/-1 log unit of the true value.
 
     Parameters
     ----------
@@ -107,7 +107,11 @@ class RegressionMetrics(EvalBase):
         "ktau": (nan_omit_ktau, True, "Kendall's $\\tau$"),
         "spearmanr": (nan_omit_spearmanr, True, "Spearman's $\\rho$"),
         "rae": (relative_absolute_error, False, "RAE"),
-        "pct_within_1_log": (pct_within_1_log_unit, False, "% within ±1 log"),
+        "pct_within_1_log": (
+            pct_within_1_log_unit,
+            False,
+            "Fraction within ±1 log",
+        ),
     }
 
     def evaluate(

--- a/openadmet/models/tests/unit/eval/test_eval.py
+++ b/openadmet/models/tests/unit/eval/test_eval.py
@@ -6,8 +6,13 @@ from openadmet.models.eval.classification import (
     ClassificationMetrics,
     ClassificationPlots,
 )
+from openadmet.models.eval.cross_validation import SKLearnRepeatedKFoldCrossValidation
 from openadmet.models.eval.eval_base import get_eval_class
-from openadmet.models.eval.regression import RegressionMetrics, RegressionPlots
+from openadmet.models.eval.regression import (
+    RegressionMetrics,
+    RegressionPlots,
+    relative_absolute_error,
+)
 
 
 def test_get_eval_class():
@@ -26,6 +31,37 @@ def test_regression_metrics():
     assert metrics["task_0"]["mse"]["value"] == 0.375
     assert metrics["task_0"]["mae"]["value"] == 0.5
     assert metrics["task_0"]["r2"]["value"] == 0.9486081370449679
+
+
+def test_regression_metrics_and_cv_include_rae_and_pct_within_1_log():
+    rm = RegressionMetrics()
+    cv = SKLearnRepeatedKFoldCrossValidation()
+
+    assert "rae" in rm.metric_names
+    assert "pct_within_1_log" in rm.metric_names
+    assert "rae" in cv.metric_names
+    assert "pct_within_1_log" in cv.metric_names
+
+
+def test_relative_absolute_error_formula():
+    y_true = np.array([1.0, 2.0, 3.0])
+    y_pred = np.array([1.0, 2.0, 4.0])
+
+    assert relative_absolute_error(y_true, y_pred) == pytest.approx(0.5)
+
+
+def test_relative_absolute_error_denominator_zero():
+    y_true = np.array([2.0, 2.0, 2.0])
+    y_pred = np.array([1.0, 2.0, 3.0])
+
+    assert relative_absolute_error(y_true, y_pred) == 0.0
+
+
+def test_cv_rae_scorer_is_minimization():
+    cv = SKLearnRepeatedKFoldCrossValidation()
+    rae_scorer, _, _ = cv._metrics["rae"]
+
+    assert rae_scorer._sign == -1
 
 
 def test_regression_plots():

--- a/openadmet/models/tests/unit/eval/test_eval.py
+++ b/openadmet/models/tests/unit/eval/test_eval.py
@@ -11,6 +11,7 @@ from openadmet.models.eval.eval_base import get_eval_class
 from openadmet.models.eval.regression import (
     RegressionMetrics,
     RegressionPlots,
+    pct_within_1_log_unit,
     relative_absolute_error,
 )
 
@@ -33,14 +34,22 @@ def test_regression_metrics():
     assert metrics["task_0"]["r2"]["value"] == 0.9486081370449679
 
 
-def test_regression_metrics_and_cv_include_rae_and_pct_within_1_log():
+def test_regression_metrics_and_cv_include_rae_and_pct_within_1_log_for_pxc50():
     rm = RegressionMetrics()
     cv = SKLearnRepeatedKFoldCrossValidation()
 
     assert "rae" in rm.metric_names
-    assert "pct_within_1_log" in rm.metric_names
+    assert "pct_within_1_log" not in rm.metric_names
     assert "rae" in cv.metric_names
-    assert "pct_within_1_log" in cv.metric_names
+    assert "pct_within_1_log" not in cv.metric_names
+
+    rm_pxc50 = RegressionMetrics(pXC50=True)
+    cv_pxc50 = SKLearnRepeatedKFoldCrossValidation(pXC50=True)
+
+    assert "rae" in rm_pxc50.metric_names
+    assert "pct_within_1_log" in rm_pxc50.metric_names
+    assert "rae" in cv_pxc50.metric_names
+    assert "pct_within_1_log" in cv_pxc50.metric_names
 
 
 def test_relative_absolute_error_formula():
@@ -55,6 +64,16 @@ def test_relative_absolute_error_denominator_zero():
     y_pred = np.array([1.0, 2.0, 3.0])
 
     assert relative_absolute_error(y_true, y_pred) == 0.0
+
+
+def test_pct_within_1_log_unit_requires_pxc50():
+    y_true = np.array([6.0, 7.0, 8.0])
+    y_pred = np.array([6.5, 7.2, 9.5])
+
+    with pytest.raises(ValueError, match="pXC50=True"):
+        pct_within_1_log_unit(y_true, y_pred)
+
+    assert pct_within_1_log_unit(y_true, y_pred, pXC50=True) == pytest.approx(2 / 3)
 
 
 def test_cv_rae_scorer_is_minimization():

--- a/openadmet/models/tests/unit/eval/test_eval.py
+++ b/openadmet/models/tests/unit/eval/test_eval.py
@@ -66,17 +66,14 @@ def test_relative_absolute_error_denominator_zero():
     y_true = np.array([2.0, 2.0, 2.0])
     y_pred = np.array([1.0, 2.0, 3.0])
 
-    assert relative_absolute_error(y_true, y_pred) == 0.0
+    assert np.isnan(relative_absolute_error(y_true, y_pred))
 
 
-def test_pct_within_1_log_unit_requires_pxc50():
+def test_pct_within_1_log_unit():
     y_true = np.array([6.0, 7.0, 8.0])
     y_pred = np.array([6.5, 7.2, 9.5])
 
-    with pytest.raises(ValueError, match="pXC50=True"):
-        pct_within_1_log_unit(y_true, y_pred)
-
-    assert pct_within_1_log_unit(y_true, y_pred, pXC50=True) == pytest.approx(2 / 3)
+    assert pct_within_1_log_unit(y_true, y_pred) == pytest.approx(2 / 3)
 
 
 def test_cv_rae_scorer_is_minimization():

--- a/openadmet/models/tests/unit/eval/test_eval.py
+++ b/openadmet/models/tests/unit/eval/test_eval.py
@@ -6,7 +6,10 @@ from openadmet.models.eval.classification import (
     ClassificationMetrics,
     ClassificationPlots,
 )
-from openadmet.models.eval.cross_validation import SKLearnRepeatedKFoldCrossValidation
+from openadmet.models.eval.cross_validation import (
+    PytorchLightningRepeatedKFoldCrossValidation,
+    SKLearnRepeatedKFoldCrossValidation,
+)
 from openadmet.models.eval.eval_base import get_eval_class
 from openadmet.models.eval.regression import (
     RegressionMetrics,
@@ -81,6 +84,16 @@ def test_cv_rae_scorer_is_minimization():
     rae_scorer, _, _ = cv._metrics["rae"]
 
     assert rae_scorer._sign == -1
+
+
+def test_lightning_cv_pct_within_1_log_uses_raw_metric_callable():
+    cv = PytorchLightningRepeatedKFoldCrossValidation(pXC50=True)
+    pct_within_1_log, _, _ = cv.active_metrics["pct_within_1_log"]
+
+    y_true = np.array([6.0, 7.0, 8.0])
+    y_pred = np.array([6.5, 7.2, 9.5])
+
+    assert pct_within_1_log(y_true, y_pred) == pytest.approx(2 / 3)
 
 
 def test_regression_plots():


### PR DESCRIPTION
## Description
Add two regression metrics and wire them into evaluator/CV reporting:
- `rae` (Relative Absolute Error)
- `pct_within_1_log` (Fraction within ±1 log)

Also includes scorer direction fix for `rae` (`greater_is_better=False`) and unit test coverage updates.

Closes #314
Closes #316

## Status
- [x] Ready to go

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenADMET/openadmet_toolkit/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
