### PR TITLE
Fix pairwise inference task index selection

### DIFF
--- a/openadmet/models/inference/inference.py
+++ b/openadmet/models/inference/inference.py
@@ -93,30 +93,35 @@ def load_anvil_model_and_metadata(model_dir):
 
 
 def _generate_pairwise_df(
-    data, input_col, feat, predictions, predictions_tag, std_tag
+    data,
+    input_col,
+    feat,
+    predictions,
+    std,
+    predictions_tag,
+    std_tag,
+    task_idx=0,
+    pairwise_df=None,
 ) -> pd.DataFrame:
     """Generate a DataFrame for pairwise predictions."""
-    smiles = data[input_col].values
-    pairwise_dataset = PairwiseAugmentedDataset(smiles, None, how=feat.how_to_pair)
-    pairs = pairwise_dataset.idxs  # list of (i, j) tuples
+    if pairwise_df is None:
+        smiles = data[input_col].values
+        pairwise_dataset = PairwiseAugmentedDataset(smiles, None, how=feat.how_to_pair)
+        pairs = pairwise_dataset.idxs  # list of (i, j) tuples
 
-    smiles_i = [smiles[i] for i, j in pairs]
-    smiles_j = [smiles[j] for i, j in pairs]
-    pred = predictions[:, j]
+        pairwise_df = pd.DataFrame(
+            {
+                f"{input_col}_i": [smiles[i] for i, _ in pairs],
+                f"{input_col}_j": [smiles[j] for _, j in pairs],
+            }
+        )
+        pairwise_df[input_col] = (
+            pairwise_df[f"{input_col}_i"] + " - " + pairwise_df[f"{input_col}_j"]
+        )
 
-    pairwise_df = pd.DataFrame(
-        {
-            f"{input_col}_i": smiles_i,
-            f"{input_col}_j": smiles_j,
-            predictions_tag: pred,
-        }
-    )
-
-    pairwise_df[std_tag] = pd.Series(predictions[:, j], index=pairwise_df.index)
-
-    pairwise_df[input_col] = (
-        pairwise_df[f"{input_col}_i"] + " - " + pairwise_df[f"{input_col}_j"]
-    )
+    task_predictions = predictions[:, task_idx]
+    pairwise_df[predictions_tag] = pd.Series(task_predictions, index=pairwise_df.index)
+    pairwise_df[std_tag] = pd.Series(std[:, task_idx], index=pairwise_df.index)
 
     return pairwise_df
 
@@ -211,6 +216,9 @@ def predict(
     warnings.filterwarnings("ignore", category=FutureWarning)
     warnings.filterwarnings("ignore", category=DeprecationWarning)
 
+    original_data = data.copy()
+    pairwise_df = None
+
     # Load the models
     for i, model_path in enumerate(model_dir):
         logger.info(f"Loading model {i} from {model_path}")
@@ -236,7 +244,8 @@ def predict(
         logger.debug(f"Feature: {feat}")
         # Returns a variable length tuple, first element is the featurized data or a dataloader
         # Second element is the indices of the original input that were featurized
-        feat_data = feat.featurize(data[input_col])
+        input_data = original_data if isinstance(feat, PairwiseFeaturizer) else data
+        feat_data = feat.featurize(input_data[input_col])
         # Features or dataloader
         X_feat = feat_data[0]
 
@@ -267,9 +276,18 @@ def predict(
                 logger.info(
                     "Detected pairwise featurizer, generating pairwise output DataFrame"
                 )
-                data = _generate_pairwise_df(
-                    data, input_col, feat, predictions, predictions_tag, std_tag
+                pairwise_df = _generate_pairwise_df(
+                    data=input_data,
+                    input_col=input_col,
+                    feat=feat,
+                    predictions=predictions,
+                    std=std,
+                    predictions_tag=predictions_tag,
+                    std_tag=std_tag,
+                    task_idx=j,
+                    pairwise_df=pairwise_df,
                 )
+                data = pairwise_df
 
             else:
                 # Add the predictions to the data DataFrame

--- a/openadmet/models/tests/unit/inference/test_inference.py
+++ b/openadmet/models/tests/unit/inference/test_inference.py
@@ -1,14 +1,28 @@
-from pathlib import Path
-import pandas as pd
 import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pandas as pd
 import pytest
 
-from openadmet.models.inference.inference import predict
+import openadmet.models.inference.inference as inference_module
 from openadmet.models.tests.unit.datafiles import (
     pred_test_data_csv,
     anvil_lgbm_trained_model_dir,
     anvil_chemprop_trained_model_dir,
 )
+
+
+class DummyPairwiseFeaturizer:
+    def __init__(self, how_to_pair="ut", featurize_spy=None):
+        self.how_to_pair = how_to_pair
+        self._featurize_spy = featurize_spy
+
+    def featurize(self, smiles):
+        if self._featurize_spy is not None:
+            self._featurize_spy(list(smiles))
+        return np.zeros((len(smiles), 1)), np.arange(len(smiles))
 
 
 @pytest.fixture
@@ -36,7 +50,7 @@ def test_predict(model_dir, request):
     output_path = None
     debug = False
 
-    result = predict(
+    result = inference_module.predict(
         input_path,
         input_col,
         model_dir,
@@ -48,3 +62,155 @@ def test_predict(model_dir, request):
 
     # Check if the result is a DataFrame
     assert isinstance(result, pd.DataFrame)
+
+
+def test_generate_pairwise_df_uses_task_idx_column():
+    data = pd.DataFrame({"SMILES": ["CCO", "CCN"]})
+    predictions = np.array([[1.0, 11.0], [2.0, 12.0], [3.0, 13.0]])
+    std = np.array([[0.1, 1.1], [0.2, 1.2], [0.3, 1.3]])
+    feat = SimpleNamespace(how_to_pair="ut")
+
+    pairwise_df = inference_module._generate_pairwise_df(
+        data=data,
+        input_col="SMILES",
+        feat=feat,
+        predictions=predictions,
+        std=std,
+        predictions_tag="pred",
+        std_tag="std",
+        task_idx=1,
+    )
+
+    assert pairwise_df["pred"].tolist() == [11.0, 12.0, 13.0]
+    assert pairwise_df["std"].tolist() == [1.1, 1.2, 1.3]
+
+
+def test_predict_single_task_pairwise_uses_column_zero(mocker):
+    model = mocker.Mock()
+    model.estimator = "dummy"
+    model.predict.return_value = np.array([[7.0], [8.0], [9.0]])
+
+    mocker.patch.object(
+        inference_module, "PairwiseFeaturizer", new=DummyPairwiseFeaturizer
+    )
+    mock_load = mocker.patch.object(
+        inference_module,
+        "load_anvil_model_and_metadata",
+        autospec=True,
+        return_value=(
+            model,
+            DummyPairwiseFeaturizer(),
+            SimpleNamespace(tag="PAIR"),
+            SimpleNamespace(target_cols=["task0"]),
+        ),
+    )
+
+    input_df = pd.DataFrame({"SMILES": ["CCO", "CCN"]})
+    result = inference_module.predict(
+        input_path=input_df,
+        input_col="SMILES",
+        model_dir="dummy_model",
+        write_csv=False,
+        output_csv=None,
+        debug=False,
+        accelerator="cpu",
+        log=False,
+    )
+
+    pred_col = "OADMET_PRED_PAIR_task0"
+    assert pred_col in result.columns
+    assert result[pred_col].tolist() == [7.0, 8.0, 9.0]
+    mock_load.assert_called_once()
+
+
+def test_predict_pairwise_multitask_keeps_original_pairs(mocker):
+    model = mocker.Mock()
+    model.estimator = "dummy"
+    model.predict.return_value = np.array([[1.0, 10.0], [2.0, 20.0], [3.0, 30.0]])
+
+    mocker.patch.object(
+        inference_module, "PairwiseFeaturizer", new=DummyPairwiseFeaturizer
+    )
+    mock_load = mocker.patch.object(
+        inference_module,
+        "load_anvil_model_and_metadata",
+        autospec=True,
+        return_value=(
+            model,
+            DummyPairwiseFeaturizer(),
+            SimpleNamespace(tag="PAIR"),
+            SimpleNamespace(target_cols=["task0", "task1"]),
+        ),
+    )
+
+    result = inference_module.predict(
+        input_path=pd.DataFrame({"SMILES": ["CCO", "CCN"]}),
+        input_col="SMILES",
+        model_dir="dummy_model",
+        write_csv=False,
+        output_csv=None,
+        debug=False,
+        accelerator="cpu",
+        log=False,
+    )
+
+    assert len(result) == 3
+    assert result["SMILES"].tolist() == ["CCO - CCO", "CCO - CCN", "CCN - CCN"]
+    assert result["OADMET_PRED_PAIR_task0"].tolist() == [1.0, 2.0, 3.0]
+    assert result["OADMET_PRED_PAIR_task1"].tolist() == [10.0, 20.0, 30.0]
+    assert result["OADMET_STD_PAIR_task0"].isna().all()
+    assert result["OADMET_STD_PAIR_task1"].isna().all()
+    mock_load.assert_called_once()
+
+
+def test_predict_pairwise_multimodel_reuses_original_input(mocker):
+    featurize_spy = mocker.Mock()
+    first_model = mocker.Mock()
+    first_model.estimator = "dummy_a"
+    first_model.predict.return_value = np.array([[1.0], [2.0], [3.0]])
+    second_model = mocker.Mock()
+    second_model.estimator = "dummy_b"
+    second_model.predict.return_value = np.array([[4.0], [5.0], [6.0]])
+
+    mocker.patch.object(
+        inference_module, "PairwiseFeaturizer", new=DummyPairwiseFeaturizer
+    )
+    mock_load = mocker.patch.object(
+        inference_module,
+        "load_anvil_model_and_metadata",
+        autospec=True,
+        side_effect=[
+            (
+                first_model,
+                DummyPairwiseFeaturizer(featurize_spy=featurize_spy),
+                SimpleNamespace(tag="PAIRA"),
+                SimpleNamespace(target_cols=["task0"]),
+            ),
+            (
+                second_model,
+                DummyPairwiseFeaturizer(featurize_spy=featurize_spy),
+                SimpleNamespace(tag="PAIRB"),
+                SimpleNamespace(target_cols=["task0"]),
+            ),
+        ],
+    )
+
+    result = inference_module.predict(
+        input_path=pd.DataFrame({"SMILES": ["CCO", "CCN"]}),
+        input_col="SMILES",
+        model_dir=["model_a", "model_b"],
+        write_csv=False,
+        output_csv=None,
+        debug=False,
+        accelerator="cpu",
+        log=False,
+    )
+
+    assert len(result) == 3
+    assert result["OADMET_PRED_PAIRA_task0"].tolist() == [1.0, 2.0, 3.0]
+    assert result["OADMET_PRED_PAIRB_task0"].tolist() == [4.0, 5.0, 6.0]
+    assert featurize_spy.call_args_list == [
+        mocker.call(["CCO", "CCN"]),
+        mocker.call(["CCO", "CCN"]),
+    ]
+    assert mock_load.call_count == 2


### PR DESCRIPTION
## Description
Fix pairwise inference dataframe generation to use explicit task index selection (`task_idx`) and add regression tests for single-task and multitask pairwise paths.

## Status
- [x] Ready to go

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenADMET/openadmet_toolkit/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
