### PR TITLE
Set explicit weights_only=True in model load path

### DIFF
--- a/openadmet/models/architecture/model_base.py
+++ b/openadmet/models/architecture/model_base.py
@@ -379,7 +379,7 @@ class LightningModelBase(ModelBase):
             Path to load the model from
 
         """
-        self.estimator.load_state_dict(torch.load(path))
+        self.estimator.load_state_dict(torch.load(path, weights_only=True))
 
     def serialize(
         self, param_path: PathLike = "model.json", serial_path: PathLike = "model.pth"

--- a/openadmet/models/tests/unit/models/test_base.py
+++ b/openadmet/models/tests/unit/models/test_base.py
@@ -1,5 +1,9 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
 import pytest
 
+import openadmet.models.architecture.model_base as model_base
 from openadmet.models.architecture.model_base import (
     LightningModelBase,
     PickleableModelBase,
@@ -29,3 +33,18 @@ def test_save_load_torch_model(mclass, tmp_path):
     loaded_model = mclass()
     loaded_model.build()
     loaded_model.load(tmp_path / "test_model.pth")
+
+
+def test_lightning_model_load_uses_weights_only(monkeypatch, tmp_path):
+    state_dict = {"layer.weight": "dummy"}
+    torch_load = Mock(return_value=state_dict)
+    monkeypatch.setattr(model_base.torch, "load", torch_load)
+
+    estimator = Mock()
+    model = SimpleNamespace(estimator=estimator)
+    path = tmp_path / "test_model.pth"
+
+    LightningModelBase.load(model, path)
+
+    torch_load.assert_called_once_with(path, weights_only=True)
+    estimator.load_state_dict.assert_called_once_with(state_dict)


### PR DESCRIPTION
## Description
Make `LightningModelBase.load` explicit and safer by using `torch.load(..., weights_only=True)` and add contract test coverage for this behavior.

Closes #437

## Status
- [x] Ready to go

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenADMET/openadmet_toolkit/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
