### PR TITLE
Replace texinfo placeholder description with project-specific text

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -209,7 +209,7 @@ texinfo_documents = [
         "openadmet_models Documentation",
         author,
         "openadmet_models",
-        "A short description of the project (less than one line).",
+        "Scalable, reproducible machine learning framework for ADMET property prediction.",
         "Miscellaneous",
     ),
 ]


### PR DESCRIPTION
## Description
Replace the default cookiecutter placeholder text in Sphinx texinfo metadata with a project-specific description.

## Status
- [x] Ready to go

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenADMET/openadmet_toolkit/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
