### PR TITLE
Fixing the cluster split warning bug

### DIFF
--- a/openadmet/models/split/cluster.py
+++ b/openadmet/models/split/cluster.py
@@ -155,9 +155,9 @@ class ClusterSplitter(SplitterBase):
         )
 
         if (
-            self.train_size != len(X_train) / total_elements
-            or self.val_size != len(X_val) / total_elements
-            or self.test_size != len(X_test) / total_elements
+            (X_train is not None and self.train_size != len(X_train) / total_elements)
+            or (X_val is not None and self.val_size != len(X_val) / total_elements)
+            or (X_test is not None and self.test_size != len(X_test) / total_elements)
         ):
             logging.warning(
                 f"Train/val/test sizes DO NOT match input requests due to cluster sizes: Train: {len(X_train) / total_elements}, Val: {len(X_val) / total_elements}, Test: {len(X_test) / total_elements}"

--- a/openadmet/models/split/cluster.py
+++ b/openadmet/models/split/cluster.py
@@ -155,12 +155,12 @@ class ClusterSplitter(SplitterBase):
         )
 
         if (
-            self.train_size != len(X_train)
+            self.train_size != len(X_train) / total_elements
             or self.val_size != len(X_val) / total_elements
             or self.test_size != len(X_test) / total_elements
         ):
             logging.warning(
-                f"Train/val/test sizes DO NOT match input requests due to cluster sizes: Train: {self.train_size / total_elements}, Val: {self.val_size / total_elements}, Test: {self.test_size / total_elements}"
+                f"Train/val/test sizes DO NOT match input requests due to cluster sizes: Train: {len(X_train) / total_elements}, Val: {len(X_val) / total_elements}, Test: {len(X_test) / total_elements}"
             )
 
         # Return train, val and test sets


### PR DESCRIPTION
## Description
The cluster split warning that uses knapsack sorting to put clusters into the train test split had a bug where it was dividing the split percentage by the total elements instead of the resulting length of each so it gives an incorrect, teeny tiny percentage. The rest of the underlying code is correct, this is just fixing the error message

## Quality Assurance & AI Policy
To maintain project quality and respect maintainer bandwidth, please confirm the following:

- [ x] **Manual Verification:** I have manually reviewed and tested the code in this PR.
- [ x] **AI-Assisted Content:** If AI tools were used (e.g., Copilot, ChatGPT), I have personally verified the logic, edge cases, and compliance with the existing codebase. I confirm the code is not a "blind" AI generation.
- [ x] **Minimal Review:** I believe this PR is in a state that requires minimal intervention or correction from maintainers.
- [ x] **Scoped Change:** This PR addresses a single, well-scoped issue rather than multiple unrelated changes.

## Status
- [ x] Ready to go (Checking this signals to maintainers that the PR is ready for final review)

## Developers Certificate of Origin
- [x ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenADMET/openadmet_toolkit/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.

---
**Note to Contributors:** We reserve the right to close PRs without review if they appear to lack human validation or do not meet the quality standards described in our `CONTRIBUTING.md`.
