### PR TITLE
Bump setup-micromamba v1 -> v2 to fix CI on Ubuntu

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -40,6 +40,7 @@ jobs:
         with:
           environment-file: devtools/conda-envs/openadmet-models.yaml
           environment-name: openadmet-models
+          cache-environment: true
           condarc: |
             channels:
               - conda-forge

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -36,7 +36,7 @@ jobs:
           ulimit -a
 
       # More info on options: https://github.com/marketplace/actions/setup-micromamba
-      - uses: mamba-org/setup-micromamba@v1
+      - uses: mamba-org/setup-micromamba@v2
         with:
           environment-file: devtools/conda-envs/openadmet-models.yaml
           environment-name: openadmet-models

--- a/.github/workflows/CI_integration.yaml
+++ b/.github/workflows/CI_integration.yaml
@@ -40,6 +40,7 @@ jobs:
         with:
           environment-file: devtools/conda-envs/openadmet-models.yaml
           environment-name: openadmet-models
+          cache-environment: true
           condarc: |
             channels:
               - conda-forge

--- a/.github/workflows/CI_integration.yaml
+++ b/.github/workflows/CI_integration.yaml
@@ -36,7 +36,7 @@ jobs:
           ulimit -a
 
       # More info on options: https://github.com/marketplace/actions/setup-micromamba
-      - uses: mamba-org/setup-micromamba@v1
+      - uses: mamba-org/setup-micromamba@v2
         with:
           environment-file: devtools/conda-envs/openadmet-models.yaml
           environment-name: openadmet-models

--- a/.github/workflows/GPU_CI_integration.yaml
+++ b/.github/workflows/GPU_CI_integration.yaml
@@ -51,7 +51,7 @@ jobs:
 
 
       # More info on options: https://github.com/marketplace/actions/setup-micromamba
-      - uses: mamba-org/setup-micromamba@v1
+      - uses: mamba-org/setup-micromamba@v2
         with:
           environment-file: devtools/conda-envs/openadmet-models-gpu.yaml
           environment-name: openadmet-models

--- a/.github/workflows/GPU_CI_integration.yaml
+++ b/.github/workflows/GPU_CI_integration.yaml
@@ -55,6 +55,7 @@ jobs:
         with:
           environment-file: devtools/conda-envs/openadmet-models-gpu.yaml
           environment-name: openadmet-models
+          cache-environment: true
           condarc: |
             channels:
               - conda-forge


### PR DESCRIPTION
## Summary

- Bumps `mamba-org/setup-micromamba` from `v1` to `v2` in all three workflow files (`CI.yaml`, `CI_integration.yaml`, `GPU_CI_integration.yaml`)
- `v1` runs on Node.js 20, which is being deprecated on GitHub Actions ubuntu runners, causing `ENOENT: no such file or directory, lstat '...micromamba-shell'` failures
- `v2` supports Node.js 24 and resolves the breakage

## Test plan

- [ ] CI (ubuntu-latest) passes on this PR
- [ ] CI (macOS-latest) continues to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)