### PR TITLE
Fix trailing slash in --output-dir producing subfolder instead of sibling

### DIFF
--- a/openadmet/models/anvil/workflow.py
+++ b/openadmet/models/anvil/workflow.py
@@ -207,8 +207,8 @@ class AnvilWorkflow(AnvilWorkflowBase):
         # Set debug attribute
         self.debug = debug
 
-        # Cast output directory to string
-        output_dir = str(output_dir)
+        # Cast output directory to string, stripping any trailing separator
+        output_dir = str(Path(output_dir))
 
         # Output directory already exists, create new handle
         if Path(output_dir).exists():
@@ -664,8 +664,8 @@ class AnvilDeepLearningWorkflow(AnvilWorkflowBase):
         # Set debug attribute
         self.debug = debug
 
-        # Cast output directory to string
-        output_dir = str(output_dir)
+        # Cast output directory to string, stripping any trailing separator
+        output_dir = str(Path(output_dir))
 
         # Output directory already exists, create new handle
         if Path(output_dir).exists():


### PR DESCRIPTION
Fixes #500

## Summary

- `--output-dir=/path/` with a trailing slash caused the hash-appended collision-avoidance path to become a subfolder (`{output_dir}/_date_hash`) instead of a sibling (`{output_dir}_date_hash`)
- Root cause: `str(output_dir)` preserves the trailing slash, so subsequent string concat `+ f"_{now}_{hsh}"` produces `/path//_date_hash`
- Fix: normalise through `Path` first (`str(Path(output_dir))`) in both workflow run methods, which strips the trailing separator before concatenation

## Test plan

- [ ] Run anvil with `--output-dir=/some/path/` on an existing directory and confirm the collision-avoidance directory is created as a sibling, not a subfolder

🤖 Generated with [Claude Code](https://claude.com/claude-code)