### PR TITLE
Fix logger=None in predict() Trainers creating stray lightning_logs/ directories

### DIFF
--- a/openadmet/models/architecture/chemprop.py
+++ b/openadmet/models/architecture/chemprop.py
@@ -581,7 +581,7 @@ class ChemPropModel(LightningModelBase):
 
         with torch.inference_mode():
             trainer = pl.Trainer(
-                logger=None,
+                logger=False,
                 enable_progress_bar=False,
                 accelerator=accelerator,
                 devices=devices,

--- a/openadmet/models/architecture/nepare.py
+++ b/openadmet/models/architecture/nepare.py
@@ -293,7 +293,7 @@ class NeuralPairwiseRegressorModel(LightningModelBase):
 
         with torch.inference_mode():
             trainer = pl.Trainer(
-                logger=None,
+                logger=False,
                 enable_progress_bar=False,
                 accelerator=accelerator,
                 devices=devices,


### PR DESCRIPTION
## Summary

- `pl.Trainer(logger=None, ...)` in PL 2.x does **not** disable logging — `None` is silently coerced to `True`, which instantiates a `TensorBoardLogger` (or `CSVLogger`) and writes `lightning_logs/version_N/` to the cwd on every call
- In an active learning run with multiple committee members, this produces hundreds of stray directories
- `logger=False` is the officially documented way to disable experiment logging in PL 2.x
- Fixed in `ChemPropModel.predict()` and `NePaReModel.predict()`

## References

PL 2.x source confirms the coercion:
```python
if logger is None:
    logger = True  # falls back to TensorBoardLogger or CSVLogger
```

## Test plan

- [x] Run `ChemPropModel.predict()` and confirm no `lightning_logs/` directory is created in the cwd
- [x] Same for `NePaReModel.predict()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)