### PR TITLE
Add pytest-mock and unit-testing standards

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -59,3 +59,13 @@ The CLI entry point is `openadmet` (`openadmet/models/cli/cli.py`), with subcomm
 - Ruff + Black formatting; isort with Black-compatible profile
 - Sentence case in comments and print statements; acronyms (MPNN, MVE, ADMET, FFN) stay capitalized
 - Do not number steps in comments; do not end comments with a period
+
+## Unit Testing & Refactoring Rules
+
+When writing or refactoring tests, you must strictly adhere to the following guidelines to ensure tests are mathematically sound, robust, and non-tautological:
+
+* **Avoid Tautological Mocks:** Do not mock the system under test. Mock heavy I/O, external dependencies, or heavy data loading, but ensure the core logic of the target function is actually executed. Use lightweight synthetic datasets (e.g., small tensors or pandas DataFrames) instead of bypassing the execution entirely.
+* **Standard Mocking:** Never write custom nested dummy classes or custom mock fixtures. Always use the standard `pytest-mock` library (the `mocker` fixture) to patch objects and verify calls.
+* **No Lazy Assertions:** Never use `assert True`. Assert actual state changes, specific dictionary keys, object types (e.g., `isinstance(obj, matplotlib.figure.Figure)`), or verify file creation via the `tmp_path` fixture.
+* **Robust ML Data Testing:** When testing data splitters or clustering algorithms, you must explicitly assert that the resulting train/validation/test sets are mutually exclusive (e.g., checking that set intersections of indices or arrays are empty). Ensure synthetic testing data has enough variance (e.g., diverse SMILES scaffolds) to meaningfully test the algorithm.
+* **Safe Floating-Point Math:** Never use strict equality (`==`) to compare floating-point numbers. Always use `pytest.approx()` or `numpy.testing.assert_almost_equal()` to prevent cross-platform precision failures. Assert the actual math (e.g., UQ or metric calculations), not just the existence of the output.

--- a/devtools/conda-envs/openadmet-models-gpu.yaml
+++ b/devtools/conda-envs/openadmet-models-gpu.yaml
@@ -33,6 +33,7 @@ dependencies:
   - pytorch_scatter
   - pytorch_sparse
   - pytest
+  - pytest-mock
   - pytest-cov
   - pytest-xdist
   - rdkit

--- a/devtools/conda-envs/openadmet-models-gpu.yaml
+++ b/devtools/conda-envs/openadmet-models-gpu.yaml
@@ -46,6 +46,7 @@ dependencies:
   - tabulate
   - umap-learn
   - uncertainty-toolbox
+  - protobuf >= 6.32.1
   - wandb
   - xgboost
   - zarr >=3.0.0

--- a/devtools/conda-envs/openadmet-models-gpu.yaml
+++ b/devtools/conda-envs/openadmet-models-gpu.yaml
@@ -1,7 +1,6 @@
 name: openadmet-models
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - ase
   - boto3
@@ -9,7 +8,6 @@ dependencies:
   - chemprop >= 2.1.1
   - codecov
   - datamol
-  - e3nn
   - h5py
   - hyperopt
   - intake
@@ -28,10 +26,6 @@ dependencies:
   - python >= 3.12,<3.14
   - pytorch-gpu
   - pytorch-lightning
-  - pytorch_cluster
-  - pytorch_geometric
-  - pytorch_scatter
-  - pytorch_sparse
   - pytest
   - pytest-mock
   - pytest-cov
@@ -48,10 +42,8 @@ dependencies:
   - uncertainty-toolbox
   - xgboost
   - zarr >=3.0.0
-  - cudatoolkit
   - pip:
     - email-validator
-    - git+https://github.com/OpenADMET/mtenn.git@main
     - phx-class-registry
     - tabpfn-extensions
     - git+https://github.com/PriorLabs/TabPFN.git@main

--- a/devtools/conda-envs/openadmet-models-gpu.yaml
+++ b/devtools/conda-envs/openadmet-models-gpu.yaml
@@ -46,6 +46,7 @@ dependencies:
   - tabulate
   - umap-learn
   - uncertainty-toolbox
+  - wandb
   - xgboost
   - zarr >=3.0.0
   - cudatoolkit
@@ -59,4 +60,3 @@ dependencies:
     - git+https://github.com/OpenADMET/molfeat.git@main
     - git+https://github.com/PatWalters/useful_rdkit_utils.git@master
     - setuptools <82.0.0
-    - wandb

--- a/devtools/conda-envs/openadmet-models-gpu.yaml
+++ b/devtools/conda-envs/openadmet-models-gpu.yaml
@@ -46,7 +46,6 @@ dependencies:
   - tabulate
   - umap-learn
   - uncertainty-toolbox
-  - wandb
   - xgboost
   - zarr >=3.0.0
   - cudatoolkit
@@ -60,3 +59,5 @@ dependencies:
     - git+https://github.com/OpenADMET/molfeat.git@main
     - git+https://github.com/PatWalters/useful_rdkit_utils.git@master
     - setuptools <82.0.0
+    - wandb
+

--- a/devtools/conda-envs/openadmet-models-gpu.yaml
+++ b/devtools/conda-envs/openadmet-models-gpu.yaml
@@ -60,4 +60,3 @@ dependencies:
     - git+https://github.com/PatWalters/useful_rdkit_utils.git@master
     - setuptools <82.0.0
     - wandb
-

--- a/devtools/conda-envs/openadmet-models-gpu.yaml
+++ b/devtools/conda-envs/openadmet-models-gpu.yaml
@@ -46,7 +46,6 @@ dependencies:
   - tabulate
   - umap-learn
   - uncertainty-toolbox
-  - wandb < 0.26.0
   - xgboost
   - zarr >=3.0.0
   - cudatoolkit
@@ -60,3 +59,4 @@ dependencies:
     - git+https://github.com/OpenADMET/molfeat.git@main
     - git+https://github.com/PatWalters/useful_rdkit_utils.git@master
     - setuptools <82.0.0
+    - wandb < 0.26.0

--- a/devtools/conda-envs/openadmet-models-gpu.yaml
+++ b/devtools/conda-envs/openadmet-models-gpu.yaml
@@ -46,8 +46,7 @@ dependencies:
   - tabulate
   - umap-learn
   - uncertainty-toolbox
-  - protobuf >= 6.32.1
-  - wandb
+  - wandb < 0.26.0
   - xgboost
   - zarr >=3.0.0
   - cudatoolkit

--- a/devtools/conda-envs/openadmet-models.yaml
+++ b/devtools/conda-envs/openadmet-models.yaml
@@ -33,6 +33,7 @@ dependencies:
   - pytorch_scatter
   - pytorch_sparse
   - pytest
+  - pytest-mock
   - pytest-cov
   - pytest-xdist
   - rdkit

--- a/devtools/conda-envs/openadmet-models.yaml
+++ b/devtools/conda-envs/openadmet-models.yaml
@@ -46,6 +46,7 @@ dependencies:
   - tabulate
   - umap-learn
   - uncertainty-toolbox
+  - protobuf >= 6.32.1
   - wandb
   - xgboost
   - zarr >=3.0.0

--- a/devtools/conda-envs/openadmet-models.yaml
+++ b/devtools/conda-envs/openadmet-models.yaml
@@ -46,7 +46,6 @@ dependencies:
   - tabulate
   - umap-learn
   - uncertainty-toolbox
-  - wandb < 0.26.0
   - xgboost
   - zarr >=3.0.0
   - pip:
@@ -59,3 +58,4 @@ dependencies:
     - git+https://github.com/OpenADMET/molfeat.git@main
     - git+https://github.com/PatWalters/useful_rdkit_utils.git@master
     - setuptools <82.0.0
+    - wandb < 0.26.0

--- a/devtools/conda-envs/openadmet-models.yaml
+++ b/devtools/conda-envs/openadmet-models.yaml
@@ -46,6 +46,7 @@ dependencies:
   - tabulate
   - umap-learn
   - uncertainty-toolbox
+  - wandb
   - xgboost
   - zarr >=3.0.0
   - pip:
@@ -58,4 +59,3 @@ dependencies:
     - git+https://github.com/OpenADMET/molfeat.git@main
     - git+https://github.com/PatWalters/useful_rdkit_utils.git@master
     - setuptools <82.0.0
-    - wandb

--- a/devtools/conda-envs/openadmet-models.yaml
+++ b/devtools/conda-envs/openadmet-models.yaml
@@ -46,8 +46,7 @@ dependencies:
   - tabulate
   - umap-learn
   - uncertainty-toolbox
-  - protobuf >= 6.32.1
-  - wandb
+  - wandb < 0.26.0
   - xgboost
   - zarr >=3.0.0
   - pip:

--- a/devtools/conda-envs/openadmet-models.yaml
+++ b/devtools/conda-envs/openadmet-models.yaml
@@ -46,7 +46,6 @@ dependencies:
   - tabulate
   - umap-learn
   - uncertainty-toolbox
-  - wandb
   - xgboost
   - zarr >=3.0.0
   - pip:
@@ -59,3 +58,4 @@ dependencies:
     - git+https://github.com/OpenADMET/molfeat.git@main
     - git+https://github.com/PatWalters/useful_rdkit_utils.git@master
     - setuptools <82.0.0
+    - wandb

--- a/devtools/conda-envs/openadmet-models.yaml
+++ b/devtools/conda-envs/openadmet-models.yaml
@@ -1,7 +1,6 @@
 name: openadmet-models
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - ase
   - boto3
@@ -9,7 +8,6 @@ dependencies:
   - chemprop >= 2.1.1
   - codecov
   - datamol
-  - e3nn
   - h5py
   - hyperopt
   - intake
@@ -28,10 +26,6 @@ dependencies:
   - python >= 3.12,<3.14
   - pytorch
   - pytorch-lightning
-  - pytorch_cluster
-  - pytorch_geometric
-  - pytorch_scatter
-  - pytorch_sparse
   - pytest
   - pytest-mock
   - pytest-cov
@@ -50,7 +44,6 @@ dependencies:
   - zarr >=3.0.0
   - pip:
     - email-validator
-    - git+https://github.com/OpenADMET/mtenn.git@main
     - phx-class-registry
     - tabpfn-extensions
     - git+https://github.com/PriorLabs/TabPFN.git@main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ requires-python = ">=3.10"
 [project.optional-dependencies]
 test = [
   "pytest>=6.1.2",
+  "pytest-mock",
 ]
 
 [project.scripts]


### PR DESCRIPTION
 ## Summary
 Introduces `pytest-mock` as a test dependency and codifies unit-testing standards in the Copilot instructions file.
 
 ### Changes
 - `pyproject.toml` — add `pytest-mock` to `[project.optional-dependencies].test`
 - `devtools/conda-envs/openadmet-models.yaml` — add `pytest-mock`
 - `devtools/conda-envs/openadmet-models-gpu.yaml` — add `pytest-mock`
 - `.github/copilot-instructions.md` — append Unit Testing & Refactoring Rules section

## Quality Assurance & AI Policy
To maintain project quality and respect maintainer bandwidth, please confirm the following:

- [X] **Manual Verification:** I have manually reviewed and tested the code in this PR.
- [X] **AI-Assisted Content:** If AI tools were used (e.g., Copilot, ChatGPT), I have personally verified the logic, edge cases, and compliance with the existing codebase. I confirm the code is not a "blind" AI generation.
- [X] **Minimal Review:** I believe this PR is in a state that requires minimal intervention or correction from maintainers.
- [X] **Scoped Change:** This PR addresses a single, well-scoped issue rather than multiple unrelated changes.

## Status
- [X] Ready to go (Checking this signals to maintainers that the PR is ready for final review)

## Developers Certificate of Origin
- [X] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenADMET/openadmet_toolkit/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.

---
**Note to Contributors:** We reserve the right to close PRs without review if they appear to lack human validation or do not meet the quality standards described in our `CONTRIBUTING.md`.
