### PR TITLE
Protobuf fix

### DIFF
--- a/devtools/conda-envs/openadmet-models.yaml
+++ b/devtools/conda-envs/openadmet-models.yaml
@@ -52,3 +52,4 @@ dependencies:
     - git+https://github.com/PatWalters/useful_rdkit_utils.git@master
     - setuptools <82.0.0
     - wandb < 0.26.0
+    - "protobuf>=6.32.1"


### PR DESCRIPTION
## Description
Fixes build error: google.protobuf.runtime_version.VersionError: ... wandb_settings.proto: gencode 6.32.1 runtime 6.31.1. Runtime version cannot be older than the linked gencode version.

## Quality Assurance & AI Policy
To maintain project quality and respect maintainer bandwidth, please confirm the following:

- [ x] **Manual Verification:** I have manually reviewed and tested the code in this PR.
- [ x] **AI-Assisted Content:** If AI tools were used (e.g., Copilot, ChatGPT), I have personally verified the logic, edge cases, and compliance with the existing codebase. I confirm the code is not a "blind" AI generation.
- [ x] **Minimal Review:** I believe this PR is in a state that requires minimal intervention or correction from maintainers.
- [ x] **Scoped Change:** This PR addresses a single, well-scoped issue rather than multiple unrelated changes.

## Status
- [ x] Ready to go (Checking this signals to maintainers that the PR is ready for final review)

## Developers Certificate of Origin
- [ x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenADMET/openadmet_toolkit/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.

---
**Note to Contributors:** We reserve the right to close PRs without review if they appear to lack human validation or do not meet the quality standards described in our `CONTRIBUTING.md`.
