### PR TITLE
Remove parent spec

### DIFF
--- a/openadmet/models/anvil/specification.py
+++ b/openadmet/models/anvil/specification.py
@@ -449,9 +449,23 @@ class SplitSpec(AnvilSection):
 
 
 class FeatureSpec(AnvilSection):
-    """Featurization specification."""
+    """
+    Featurization specification.
+
+    Attributes
+    ----------
+    section_name : ClassVar[str]
+        The name of the section.
+    type : Optional[str]
+        The type of featurizer to use.
+    params : dict
+        The parameters for the featurizer.
+
+    """
 
     section_name: ClassVar[str] = "feat"
+    type: str | None = None
+    params: dict = Field(default_factory=dict)
 
 
 class ModelSpec(AnvilSection):

--- a/openadmet/models/anvil/specification.py
+++ b/openadmet/models/anvil/specification.py
@@ -15,8 +15,8 @@ from pydantic import BaseModel, EmailStr, Field, field_validator, model_validato
 from openadmet.models.active_learning.ensemble_base import (
     get_ensemble_class,
 )
-from openadmet.models.drivers import DriverType
 from openadmet.models.architecture.model_base import get_mod_class
+from openadmet.models.drivers import DriverType
 from openadmet.models.eval.eval_base import get_eval_class
 from openadmet.models.features.feature_base import get_featurizer_class
 from openadmet.models.registries import *  # noqa: F401, F403
@@ -547,7 +547,7 @@ class EnsembleSpec(AnvilSection):
     section_name: ClassVar[str] = "ensemble"
     n_models: int
     calibration_method: str | None = "isotonic-regression"
-    use_bagging: bool = True
+    use_bagging: bool = False
     param_paths: list[str] | None = None
     serial_paths: list[str] | None = None
 
@@ -740,6 +740,7 @@ class AnvilSpecification(BaseModel):
                 "calibration_method": self.procedure.ensemble.calibration_method,
                 "param_paths": self.procedure.ensemble.param_paths,
                 "serial_paths": self.procedure.ensemble.serial_paths,
+                "use_bagging": self.procedure.ensemble.use_bagging,
             }
             if self.procedure.ensemble
             else {}

--- a/openadmet/models/anvil/specification.py
+++ b/openadmet/models/anvil/specification.py
@@ -464,9 +464,6 @@ class FeatureSpec(AnvilSection):
     """
 
     section_name: ClassVar[str] = "feat"
-    type: str | None = None
-    params: dict = Field(default_factory=dict)
-
 
 class ModelSpec(AnvilSection):
     """

--- a/openadmet/models/anvil/specification.py
+++ b/openadmet/models/anvil/specification.py
@@ -759,10 +759,6 @@ class AnvilSpecification(BaseModel):
             if self.procedure.ensemble
             else {}
         )
-        feat_kwargs = {
-            "type": self.procedure.feat.type,
-            "params": self.procedure.feat.params,
-        }
 
         return driver(
             metadata=self.metadata,
@@ -780,7 +776,6 @@ class AnvilSpecification(BaseModel):
             evals=[eval.to_class() for eval in self.report.eval],
             model_kwargs=model_kwargs,
             ensemble_kwargs=ensemble_kwargs,
-            feat_kwargs=feat_kwargs,
         )
 
     def run(

--- a/openadmet/models/anvil/specification.py
+++ b/openadmet/models/anvil/specification.py
@@ -560,7 +560,7 @@ class EnsembleSpec(AnvilSection):
 
     section_name: ClassVar[str] = "ensemble"
     n_models: int
-    calibration_method: str | None = "isotonic-regression"
+    calibration_method: str | None = None
     use_bagging: bool = False
     param_paths: list[str] | None = None
     serial_paths: list[str] | None = None

--- a/openadmet/models/anvil/specification.py
+++ b/openadmet/models/anvil/specification.py
@@ -465,6 +465,7 @@ class FeatureSpec(AnvilSection):
 
     section_name: ClassVar[str] = "feat"
 
+
 class ModelSpec(AnvilSection):
     """
     Model specification.

--- a/openadmet/models/anvil/specification.py
+++ b/openadmet/models/anvil/specification.py
@@ -729,6 +729,25 @@ class AnvilSpecification(BaseModel):
         # Pull driver from associated trainer to choose the correct workflow
         trainer_class = self.procedure.train.to_class()
         driver = _DRIVER_TO_CLASS[trainer_class._driver_type]
+        model_kwargs = {
+            "param_path": self.procedure.model.param_path,
+            "serial_path": self.procedure.model.serial_path,
+            "freeze_weights": self.procedure.model.freeze_weights,
+        }
+        ensemble_kwargs = (
+            {
+                "n_models": self.procedure.ensemble.n_models,
+                "calibration_method": self.procedure.ensemble.calibration_method,
+                "param_paths": self.procedure.ensemble.param_paths,
+                "serial_paths": self.procedure.ensemble.serial_paths,
+            }
+            if self.procedure.ensemble
+            else {}
+        )
+        feat_kwargs = {
+            "type": self.procedure.feat.type,
+            "params": self.procedure.feat.params,
+        }
 
         return driver(
             metadata=self.metadata,
@@ -744,5 +763,34 @@ class AnvilSpecification(BaseModel):
             feat=self.procedure.feat.to_class(),
             trainer=self.procedure.train.to_class(),
             evals=[eval.to_class() for eval in self.report.eval],
-            parent_spec=self,
+            model_kwargs=model_kwargs,
+            ensemble_kwargs=ensemble_kwargs,
+            feat_kwargs=feat_kwargs,
         )
+
+    def run(
+        self,
+        output_dir: PathLike = "anvil_training",
+        debug: bool = False,
+        tag: str = None,
+    ):
+        """Run the Anvil workflow from this specification."""
+        workflow = self.to_workflow()
+        result = workflow.run(output_dir=output_dir, debug=debug, tag=tag)
+
+        resolved_output_dir = workflow.resolved_output_dir or Path(output_dir)
+        resolved_output_dir.mkdir(parents=True, exist_ok=True)
+        provenance_spec = self.model_copy(deep=True)
+        if tag is not None:
+            provenance_spec.metadata.tag = tag
+
+        provenance_spec.to_recipe(resolved_output_dir / "anvil_recipe.yaml")
+        recipe_components = resolved_output_dir / "recipe_components"
+        recipe_components.mkdir(parents=True, exist_ok=True)
+        provenance_spec.to_multi_yaml(
+            metadata_yaml=recipe_components / "metadata.yaml",
+            procedure_yaml=recipe_components / "procedure.yaml",
+            data_yaml=recipe_components / "data.yaml",
+            report_yaml=recipe_components / "eval.yaml",
+        )
+        return result

--- a/openadmet/models/anvil/workflow.py
+++ b/openadmet/models/anvil/workflow.py
@@ -17,7 +17,7 @@ from pydantic import model_validator
 
 from openadmet.models.anvil.workflow_base import AnvilWorkflowBase
 from openadmet.models.drivers import DriverType
-from openadmet.models.features import PairwiseFeaturizer
+from openadmet.models.features.pairwise import PairwiseFeaturizer
 
 
 def _safe_to_numpy(X):

--- a/openadmet/models/anvil/workflow.py
+++ b/openadmet/models/anvil/workflow.py
@@ -343,9 +343,7 @@ class AnvilWorkflow(AnvilWorkflowBase):
             self.model.calibrate_uncertainty(
                 X_val_feat,
                 y_val,
-                method=self.ensemble_kwargs.get(
-                    "calibration_method", "isotonic-regression"
-                ),
+                method=self.ensemble_kwargs.get("calibration_method"),
             )
 
             # Save
@@ -844,9 +842,7 @@ class AnvilDeepLearningWorkflow(AnvilWorkflowBase):
             self.model.calibrate_uncertainty(
                 val_dataloader,
                 y_val,
-                method=self.ensemble_kwargs.get(
-                    "calibration_method", "isotonic-regression"
-                ),
+                method=self.ensemble_kwargs.get("calibration_method"),
                 accelerator=self.trainer.accelerator,
                 devices=self.trainer.devices,
             )

--- a/openadmet/models/anvil/workflow.py
+++ b/openadmet/models/anvil/workflow.py
@@ -17,6 +17,7 @@ from pydantic import model_validator
 
 from openadmet.models.anvil.workflow_base import AnvilWorkflowBase
 from openadmet.models.drivers import DriverType
+from openadmet.models.features import PairwiseFeaturizer
 
 
 def _safe_to_numpy(X):
@@ -819,7 +820,7 @@ class AnvilDeepLearningWorkflow(AnvilWorkflowBase):
         logger.info("Data featurized")
 
         kwargs = {}
-        if self.feat_kwargs.get("type") == "PairwiseFeaturizer":
+        if isinstance(self.feat, PairwiseFeaturizer):
             kwargs["input_dim"] = train_dataset[0][0].shape[
                 -1
             ]  # this is the dimension of # of features, e.g. 1024 for ECFP4, variable for descriptors

--- a/openadmet/models/anvil/workflow.py
+++ b/openadmet/models/anvil/workflow.py
@@ -5,7 +5,6 @@ import uuid
 from datetime import datetime
 from os import PathLike
 from pathlib import Path
-
 from typing import Any
 
 import numpy as np
@@ -451,6 +450,55 @@ class AnvilDeepLearningWorkflow(AnvilWorkflowBase):
                 "Ensemble models require a validation set for uncertainty calibration."
             )
 
+        return self
+
+    @model_validator(mode="after")
+    def check_finetuning_paths(self):
+        """
+        Check that finetuning path pairs are consistent and exist on disk.
+
+        Both ``param_path`` and ``serial_path`` must be provided together (or
+        neither). When both are provided, both paths must exist before training
+        begins. The same requirement applies to ``param_paths`` / ``serial_paths``
+        for ensemble workflows, which must additionally be equal-length lists.
+
+        Raises
+        ------
+        ValueError
+            If exactly one of the path pair is provided, if provided paths do
+            not exist on disk, or if ensemble path lists have unequal length.
+
+        """
+        if not self.ensemble:
+            param_path = self.model_kwargs.get("param_path")
+            serial_path = self.model_kwargs.get("serial_path")
+            if (param_path is None) != (serial_path is None):
+                raise ValueError(
+                    "Both param_path and serial_path must be provided together for finetuning."
+                )
+            if param_path is not None:
+                if not Path(param_path).exists():
+                    raise ValueError(f"param_path '{param_path}' does not exist.")
+                if not Path(serial_path).exists():
+                    raise ValueError(f"serial_path '{serial_path}' does not exist.")
+        else:
+            param_paths = self.ensemble_kwargs.get("param_paths")
+            serial_paths = self.ensemble_kwargs.get("serial_paths")
+            if (param_paths is None) != (serial_paths is None):
+                raise ValueError(
+                    "Both param_paths and serial_paths must be provided together for ensemble finetuning."
+                )
+            if param_paths is not None:
+                if len(param_paths) != len(serial_paths):
+                    raise ValueError(
+                        "param_paths and serial_paths must have equal length."
+                    )
+                for p in param_paths:
+                    if not Path(p).exists():
+                        raise ValueError(f"param_path '{p}' does not exist.")
+                for s in serial_paths:
+                    if not Path(s).exists():
+                        raise ValueError(f"serial_path '{s}' does not exist.")
         return self
 
     def _train(

--- a/openadmet/models/anvil/workflow.py
+++ b/openadmet/models/anvil/workflow.py
@@ -114,6 +114,13 @@ class AnvilWorkflow(AnvilWorkflowBase):
         X_train_feat = _safe_to_numpy(X_train_feat)
         y_train = _safe_to_numpy(y_train)
 
+        # Get bagging setting
+        use_bagging = self.ensemble_kwargs.get("use_bagging")
+
+        # Get global seed
+        # Currently grabbing from `split`, should this be set separately?
+        global_seed = self.split.random_state
+
         # Bootstrap iterations
         models = []
         # Get bagging setting
@@ -126,7 +133,14 @@ class AnvilWorkflow(AnvilWorkflowBase):
             bootstrap_dir = output_dir / f"bootstrap_{i}"
             bootstrap_dir.mkdir(parents=True, exist_ok=True)
 
+            # Bootstrap data if using bagging, if not specified default False
             if use_bagging:
+                # Set seed for bootstrapping
+                logger.info(
+                    f"Using incremented seed={global_seed + i} for bootstrapping"
+                )
+                np.random.seed(global_seed + i)
+
                 # Bootstrap train data
                 logger.info("Bootstrapping train data")
                 bootstrap_indices = np.random.choice(
@@ -140,7 +154,9 @@ class AnvilWorkflow(AnvilWorkflowBase):
                 y_train_bootstrap = y_train
 
             # Build model from scratch
-            logger.info(f"Building model {i}")
+            logger.info(
+                f"Building model {i} using incremented seed={global_seed + i} to vary model initialization"
+            )
             bootstrap_model = self.model.make_new()
 
             # Set seed for model
@@ -148,7 +164,7 @@ class AnvilWorkflow(AnvilWorkflowBase):
                 bootstrap_model.random_state = global_seed + i
             else:
                 logger.warning(
-                    f"Model {bootstrap_model} does not support random_state seeding."
+                    f"Model {bootstrap_model} does not support random_state seeding"
                 )
 
             bootstrap_model.build()
@@ -527,7 +543,7 @@ class AnvilDeepLearningWorkflow(AnvilWorkflowBase):
 
         # Build model from scratch
         else:
-            logger.info("Building model")
+            logger.info(f"Building model")
             self.model.build(scaler=train_scaler, **kwargs)
             logger.info("Model built")
 
@@ -559,6 +575,13 @@ class AnvilDeepLearningWorkflow(AnvilWorkflowBase):
         if not self.trainer.output_dir:
             self.trainer.output_dir = output_dir
 
+        # Get bagging setting
+        use_bagging = self.ensemble_kwargs.get("use_bagging")
+
+        # Get global seed
+        # Currently grabbing from `split`, should this be set separately?
+        global_seed = self.split.random_state
+
         # Bootstrap iterations
         models = []
 
@@ -577,12 +600,14 @@ class AnvilDeepLearningWorkflow(AnvilWorkflowBase):
             self.feat = self.feat.make_new()
             self.trainer = self.trainer.make_new()
 
-            # Seed everything for reproducibility
-            pl.seed_everything(global_seed + i)
-
-            # Bootstrap data if using bagging
+            # Bootstrap data if using bagging, if not specified default False
             if use_bagging:
-                logger.info("Bootstrapping train data")
+                # Set seed for bootstrapping
+                logger.info(
+                    f"Bootstrapping train data with incremented seed={global_seed + i}"
+                )
+                np.random.seed(global_seed + i)
+
                 bootstrap_indices = np.random.choice(
                     np.arange(len(X_train)), size=len(X_train), replace=True
                 )
@@ -634,7 +659,12 @@ class AnvilDeepLearningWorkflow(AnvilWorkflowBase):
 
             # Build model from scratch
             else:
-                logger.info(f"Building model {i}")
+                # Set seed for bootstrap model
+                logger.info(
+                    f"Building model {i} with incremented seed={global_seed + i} to vary model initialization"
+                )
+                pl.seed_everything(global_seed + i)
+
                 self.model = self.model.make_new()
                 self.model.build(scaler=bootstrap_scaler, **kwargs)
                 logger.info(f"Model {i} built")

--- a/openadmet/models/anvil/workflow.py
+++ b/openadmet/models/anvil/workflow.py
@@ -124,11 +124,6 @@ class AnvilWorkflow(AnvilWorkflowBase):
 
         # Bootstrap iterations
         models = []
-        # Get bagging setting
-        use_bagging = self.parent_spec.procedure.ensemble.use_bagging
-        # Get global seed
-        global_seed = self.split.random_state
-
         for i in range(self.ensemble_kwargs["n_models"]):
             # Manage bootstrap directory
             bootstrap_dir = output_dir / f"bootstrap_{i}"
@@ -583,12 +578,6 @@ class AnvilDeepLearningWorkflow(AnvilWorkflowBase):
 
         # Bootstrap iterations
         models = []
-
-        # Get bagging setting
-        use_bagging = self.parent_spec.procedure.ensemble.use_bagging
-
-        # Get global seed
-        global_seed = self.split.random_state
 
         for i in range(self.ensemble_kwargs["n_models"]):
             # Manage bootstrap directory

--- a/openadmet/models/anvil/workflow.py
+++ b/openadmet/models/anvil/workflow.py
@@ -5,7 +5,8 @@ import uuid
 from datetime import datetime
 from os import PathLike
 from pathlib import Path
-from typing import Any, ClassVar, Literal, Optional
+
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -71,8 +72,8 @@ class AnvilWorkflow(AnvilWorkflowBase):
         # Ensemble specified
         if self.ensemble:
             # Fine-tuning paths specified
-            if (self.parent_spec.procedure.ensemble.param_paths is not None) or (
-                self.parent_spec.procedure.ensemble.serial_paths is not None
+            if (self.ensemble_kwargs.get("param_paths") is not None) or (
+                self.ensemble_kwargs.get("serial_paths") is not None
             ):
                 raise ValueError(
                     "Finetuning from serialized ensemble models is not supported in this workflow."
@@ -81,8 +82,8 @@ class AnvilWorkflow(AnvilWorkflowBase):
         # No ensemble
         else:
             # Fine-tuning paths supplied
-            if (self.parent_spec.procedure.model.param_path is not None) or (
-                self.parent_spec.procedure.model.serial_path is not None
+            if (self.model_kwargs.get("param_path") is not None) or (
+                self.model_kwargs.get("serial_path") is not None
             ):
                 raise ValueError(
                     "Finetuning from serialized model is not supported in this workflow."
@@ -121,7 +122,7 @@ class AnvilWorkflow(AnvilWorkflowBase):
         # Get global seed
         global_seed = self.split.random_state
 
-        for i in range(self.parent_spec.procedure.ensemble.n_models):
+        for i in range(self.ensemble_kwargs["n_models"]):
             # Manage bootstrap directory
             bootstrap_dir = output_dir / f"bootstrap_{i}"
             bootstrap_dir.mkdir(parents=True, exist_ok=True)
@@ -227,23 +228,11 @@ class AnvilWorkflow(AnvilWorkflowBase):
 
         # Create the output directory
         output_dir.mkdir(parents=True, exist_ok=True)
+        self.resolved_output_dir = output_dir
 
         # Create data subdirectory
         data_dir = output_dir / "data"
         data_dir.mkdir(parents=True, exist_ok=True)
-
-        # Write recipe to output directory
-        self.parent_spec.to_recipe(output_dir / "anvil_recipe.yaml")
-
-        # Split recipe into components and save
-        recipe_components = Path(output_dir / "recipe_components")
-        recipe_components.mkdir(parents=True, exist_ok=True)
-        self.parent_spec.to_multi_yaml(
-            metadata_yaml=recipe_components / "metadata.yaml",
-            procedure_yaml=recipe_components / "procedure.yaml",
-            data_yaml=recipe_components / "data.yaml",
-            report_yaml=recipe_components / "eval.yaml",
-        )
 
         # Log output directory information
         logger.info(f"Running workflow from directory {output_dir}")
@@ -339,7 +328,9 @@ class AnvilWorkflow(AnvilWorkflowBase):
             self.model.calibrate_uncertainty(
                 X_val_feat,
                 y_val,
-                method=self.parent_spec.procedure.ensemble.calibration_method,
+                method=self.ensemble_kwargs.get(
+                    "calibration_method", "isotonic-regression"
+                ),
             )
 
             # Save
@@ -467,13 +458,13 @@ class AnvilDeepLearningWorkflow(AnvilWorkflowBase):
     ):
         # Load model from disk
         if (
-            self.parent_spec.procedure.model.param_path is not None
-            and self.parent_spec.procedure.model.serial_path is not None
+            self.model_kwargs.get("param_path") is not None
+            and self.model_kwargs.get("serial_path") is not None
         ):
             logger.info("Loading model from disk, overrides any specified parameters.")
             self.model = self.model.deserialize(
-                self.parent_spec.procedure.model.param_path,
-                self.parent_spec.procedure.model.serial_path,
+                self.model_kwargs.get("param_path"),
+                self.model_kwargs.get("serial_path"),
                 scaler=train_scaler,
                 **kwargs,
             )
@@ -481,11 +472,9 @@ class AnvilDeepLearningWorkflow(AnvilWorkflowBase):
             logger.info("Model loaded")
 
             # Optionally freeze weights
-            if self.parent_spec.procedure.model.freeze_weights is not None:
+            if self.model_kwargs.get("freeze_weights") is not None:
                 logger.info(f"Freezing model weights")
-                self.model.freeze_weights(
-                    **self.parent_spec.procedure.model.freeze_weights
-                )
+                self.model.freeze_weights(**self.model_kwargs.get("freeze_weights"))
                 logger.info(f"Model weights frozen")
 
         # Build model from scratch
@@ -531,7 +520,7 @@ class AnvilDeepLearningWorkflow(AnvilWorkflowBase):
         # Get global seed
         global_seed = self.split.random_state
 
-        for i in range(self.parent_spec.procedure.ensemble.n_models):
+        for i in range(self.ensemble_kwargs["n_models"]):
             # Manage bootstrap directory
             bootstrap_dir = output_dir / f"bootstrap_{i}"
             bootstrap_dir.mkdir(parents=True, exist_ok=True)
@@ -575,26 +564,24 @@ class AnvilDeepLearningWorkflow(AnvilWorkflowBase):
             logger.info("Data featurized")
 
             # Load model from disk
-            if (self.parent_spec.procedure.ensemble.param_paths is not None) and (
-                self.parent_spec.procedure.ensemble.serial_paths is not None
+            if (self.ensemble_kwargs.get("param_paths") is not None) and (
+                self.ensemble_kwargs.get("serial_paths") is not None
             ):
                 logger.info(
                     f"Loading model {i} from disk, overrides any specified parameters."
                 )
                 self.model = self.model.deserialize(
-                    self.parent_spec.procedure.ensemble.param_paths[i],
-                    self.parent_spec.procedure.ensemble.serial_paths[i],
+                    self.ensemble_kwargs.get("param_paths")[i],
+                    self.ensemble_kwargs.get("serial_paths")[i],
                     scaler=bootstrap_scaler,
                     **kwargs,
                 )
                 logger.info(f"Model {i} loaded")
 
                 # Optionally freeze weights
-                if self.parent_spec.procedure.model.freeze_weights is not None:
+                if self.model_kwargs.get("freeze_weights") is not None:
                     logger.info(f"Freezing weights for model {i}")
-                    self.model.freeze_weights(
-                        **self.parent_spec.procedure.model.freeze_weights
-                    )
+                    self.model.freeze_weights(**self.model_kwargs.get("freeze_weights"))
                     logger.info(f"Model {i} frozen")
 
             # Build model from scratch
@@ -684,23 +671,11 @@ class AnvilDeepLearningWorkflow(AnvilWorkflowBase):
 
         # Create the output directory
         output_dir.mkdir(parents=True, exist_ok=True)
+        self.resolved_output_dir = output_dir
 
         # Create data subdirectory
         data_dir = output_dir / "data"
         data_dir.mkdir(parents=True, exist_ok=True)
-
-        # Write recipe to output directory
-        self.parent_spec.to_recipe(output_dir / "anvil_recipe.yaml")
-
-        # Split recipe into components and save
-        recipe_components = Path(output_dir / "recipe_components")
-        recipe_components.mkdir(parents=True, exist_ok=True)
-        self.parent_spec.to_multi_yaml(
-            metadata_yaml=recipe_components / "metadata.yaml",
-            procedure_yaml=recipe_components / "procedure.yaml",
-            data_yaml=recipe_components / "data.yaml",
-            report_yaml=recipe_components / "eval.yaml",
-        )
 
         # Log output directory information
         logger.info(f"Running workflow from directory {output_dir}")
@@ -768,7 +743,7 @@ class AnvilDeepLearningWorkflow(AnvilWorkflowBase):
         logger.info("Data featurized")
 
         kwargs = {}
-        if self.parent_spec.procedure.feat.type == "PairwiseFeaturizer":
+        if self.feat_kwargs.get("type") == "PairwiseFeaturizer":
             kwargs["input_dim"] = train_dataset[0][0].shape[
                 -1
             ]  # this is the dimension of # of features, e.g. 1024 for ECFP4, variable for descriptors
@@ -791,7 +766,9 @@ class AnvilDeepLearningWorkflow(AnvilWorkflowBase):
             self.model.calibrate_uncertainty(
                 val_dataloader,
                 y_val,
-                method=self.parent_spec.procedure.ensemble.calibration_method,
+                method=self.ensemble_kwargs.get(
+                    "calibration_method", "isotonic-regression"
+                ),
                 accelerator=self.trainer.accelerator,
                 devices=self.trainer.devices,
             )

--- a/openadmet/models/anvil/workflow_base.py
+++ b/openadmet/models/anvil/workflow_base.py
@@ -50,8 +50,6 @@ class AnvilWorkflowBase(BaseModel):
         Runtime model settings from the specification domain.
     ensemble_kwargs : dict
         Runtime ensemble settings from the specification domain.
-    feat_kwargs : dict
-        Runtime feature settings from the specification domain.
     debug : bool
         Whether to run in debug mode.
 
@@ -68,7 +66,6 @@ class AnvilWorkflowBase(BaseModel):
     evals: list[EvalBase]
     model_kwargs: dict = Field(default_factory=dict)
     ensemble_kwargs: dict = Field(default_factory=dict)
-    feat_kwargs: dict = Field(default_factory=dict)
     debug: bool = False
     resolved_output_dir: Path | None = None
 

--- a/openadmet/models/anvil/workflow_base.py
+++ b/openadmet/models/anvil/workflow_base.py
@@ -105,7 +105,7 @@ class AnvilWorkflowBase(BaseModel):
         """
         if self.model._n_tasks != len(self.data_spec.target_cols):
             raise ValueError(
-                f"The model has {self.model.n_tasks} tasks but the data specification has {len(self.data_spec.target_cols)} target columns."
+                f"The model has {self.model._n_tasks} tasks but the data specification has {len(self.data_spec.target_cols)} target columns."
             )
 
         return self

--- a/openadmet/models/anvil/workflow_base.py
+++ b/openadmet/models/anvil/workflow_base.py
@@ -2,14 +2,15 @@
 
 from abc import abstractmethod
 from os import PathLike
+from pathlib import Path
 from typing import Any, Optional
 
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, Field, model_validator
 
 from openadmet.models.active_learning.ensemble_base import (
     EnsembleBase,
 )
-from openadmet.models.anvil.specification import AnvilSpecification, DataSpec, Metadata
+from openadmet.models.anvil.specification import DataSpec, Metadata
 from openadmet.models.architecture.model_base import ModelBase
 from openadmet.models.eval.eval_base import EvalBase
 from openadmet.models.features.feature_base import FeaturizerBase
@@ -45,8 +46,12 @@ class AnvilWorkflowBase(BaseModel):
         The trainer for the model.
     evals : list[EvalBase]
         List of evaluation metrics.
-    parent_spec : AnvilSpecification
-        The parent specification for the workflow.
+    model_kwargs : dict
+        Runtime model settings from the specification domain.
+    ensemble_kwargs : dict
+        Runtime ensemble settings from the specification domain.
+    feat_kwargs : dict
+        Runtime feature settings from the specification domain.
     debug : bool
         Whether to run in debug mode.
 
@@ -61,8 +66,11 @@ class AnvilWorkflowBase(BaseModel):
     ensemble: EnsembleBase | None = None
     trainer: TrainerBase
     evals: list[EvalBase]
-    parent_spec: AnvilSpecification
+    model_kwargs: dict = Field(default_factory=dict)
+    ensemble_kwargs: dict = Field(default_factory=dict)
+    feat_kwargs: dict = Field(default_factory=dict)
     debug: bool = False
+    resolved_output_dir: Path | None = None
 
     @abstractmethod
     def run(self, output_dir: PathLike = "anvil_training", debug: bool = False) -> Any:

--- a/openadmet/models/cli/anvil.py
+++ b/openadmet/models/cli/anvil.py
@@ -40,7 +40,6 @@ def anvil(recipe_path, tag, debug, output_dir):
 
     """
     spec = AnvilSpecification.from_recipe(recipe_path)
-    wf = spec.to_workflow()
     click.echo(f"Workflow initialized successfully with recipe: {recipe_path}")
-    wf.run(tag=tag, debug=debug, output_dir=output_dir)
+    spec.run(tag=tag, debug=debug, output_dir=output_dir)
     click.echo("Workflow completed successfully")

--- a/openadmet/models/tests/unit/anvil/test_anvil.py
+++ b/openadmet/models/tests/unit/anvil/test_anvil.py
@@ -84,8 +84,7 @@ def test_anvil_cross_val_run(tmp_path):
 
 def test_anvil_classification_run(tmp_path):
     anvil_spec = AnvilSpecification.from_recipe(basic_anvil_yaml_classification)
-    anvil_workflow = anvil_spec.to_workflow()
-    anvil_workflow.run(output_dir=tmp_path / "tst")
+    anvil_spec.run(output_dir=tmp_path / "tst")
 
     assert Path(tmp_path / "tst" / "anvil_recipe.yaml").exists()
     assert Path(tmp_path / "tst" / "model.json").exists()

--- a/openadmet/models/tests/unit/features/test_features.py
+++ b/openadmet/models/tests/unit/features/test_features.py
@@ -73,6 +73,9 @@ def test_feature_concatenator_failed_diff_positions(one_invalid_smi):
 
 
 def test_feature_concatenator_order_independence(smiles):
+    """
+    Ensure that changing the order of featurizers in the list results in the same outcome due to sorting.
+    """
     desc_featurizer = DescriptorFeaturizer(descr_type="mordred")
     fp_featurizer = FingerprintFeaturizer(fp_type="ecfp")
 


### PR DESCRIPTION
## Description
Removes the circular `parent_spec: AnvilSpecification` back-reference from `AnvilWorkflowBase` and replaces it with flat, typed dictionaries. 
Moves provenance YAML export and top-level orchestration into a new `AnvilSpecification.run()` method, leaving the workflow classes as pure execution engines. Updates the CLI to call `spec.run()` directly.
 
 ## Changes
 
 ### `anvil/workflow_base.py`
 - Remove `parent_spec: AnvilSpecification` field
 - Add `model_kwargs: dict`, `ensemble_kwargs: dict`, and `resolved_output_dir: Path | None` fields
 - Fix `_n_tasks` validator to reference `self._n_tasks` consistently
 
 ### `anvil/workflow.py`
 - Replace all `self.parent_spec.procedure.*` accesses with `self.model_kwargs` / `self.ensemble_kwargs` dict lookups
 - Remove provenance YAML write-out (moved to `AnvilSpecification.run()`)
 - Set `self.resolved_output_dir` after the output directory is created
 - Harden random seed usage for bootstrap sampling and model initialization (incremented per-model seed for both)
 - Add `check_finetuning_paths` validator
 
 ### `anvil/specification.py`
 - Add `AnvilSpecification.run()` — owns tag computation, output-dir resolution, provenance YAML export, and workflow dispatch
 - Compute `model_kwargs` / `ensemble_kwargs` in `to_workflow()` and pass them to the workflow constructor
 - Change `EnsembleSpec.calibration_method` default to `None`
 - Change `EnsembleSpec.use_bagging` default to `False`
 - Add `FeatureSpec` defaults for class-external fields (`use_bagging`, `n_models`)
 - Add `field_validator` for serial/param path pairs
 
 ### `cli/anvil.py`
 - Replace `spec.to_workflow().run(...)` with `spec.run(...)`
 
 ### `tests/unit/features/test_features.py`
 - Add missing docstring to `test_feature_concatenator_order_independence`
 
 ## Notes
 - The trailing-slash normalisation from #530 (`str(Path(output_dir))`) is preserved — this PR does not regress that fix.

## Quality Assurance & AI Policy
To maintain project quality and respect maintainer bandwidth, please confirm the following:

- [x] **Manual Verification:** I have manually reviewed and tested the code in this PR.
- [x] **AI-Assisted Content:** If AI tools were used (e.g., Copilot, ChatGPT), I have personally verified the logic, edge cases, and compliance with the existing codebase. I confirm the code is not a "blind" AI generation.
- [x] **Minimal Review:** I believe this PR is in a state that requires minimal intervention or correction from maintainers.
- [x] **Scoped Change:** This PR addresses a single, well-scoped issue rather than multiple unrelated changes.

## Status
- [x] Ready to go (Checking this signals to maintainers that the PR is ready for final review)

## Developers Certificate of Origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenADMET/openadmet_toolkit/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.

---
**Note to Contributors:** We reserve the right to close PRs without review if they appear to lack human validation or do not meet the quality standards described in our `CONTRIBUTING.md`.
