### PR TITLE
pin pytorch-lightning<=2.6.1

### DIFF
--- a/devtools/conda-envs/openadmet-models-gpu.yaml
+++ b/devtools/conda-envs/openadmet-models-gpu.yaml
@@ -25,7 +25,7 @@ dependencies:
   - pip
   - python >= 3.12,<3.14
   - pytorch-gpu
-  - pytorch-lightning
+  - pytorch-lightning<=2.6.1
   - pytest
   - pytest-mock
   - pytest-cov

--- a/devtools/conda-envs/openadmet-models.yaml
+++ b/devtools/conda-envs/openadmet-models.yaml
@@ -25,7 +25,7 @@ dependencies:
   - pip
   - python >= 3.12,<3.14
   - pytorch
-  - pytorch-lightning
+  - pytorch-lightning<=2.6.1
   - pytest
   - pytest-mock
   - pytest-cov


### PR DESCRIPTION
Per the guidance in https://github.com/Lightning-AI/pytorch-lightning/security/advisories/GHSA-w37p-236h-pfx3 pytorch-lightning should be pinned to <=2.6.1