### PR TITLE
Fix pandas 3.0 compatibility in PostHocComparison

### DIFF
--- a/openadmet/models/comparison/posthoc.py
+++ b/openadmet/models/comparison/posthoc.py
@@ -755,7 +755,7 @@ class PostHocComparison(ComparisonBase):
             if reverse_cmap:
                 cmap = cmap + "_r"
 
-            significance = pd.DataFrame(hsd.pvalue)
+            significance = pd.DataFrame(hsd.pvalue).astype(object)
             significance[(hsd.pvalue < self.sig_levels[2]) & (hsd.pvalue >= 0)] = "***"
             significance[
                 (hsd.pvalue < self.sig_levels[1]) & (hsd.pvalue >= self.sig_levels[2])

--- a/openadmet/models/tests/unit/comparison/test_comparison.py
+++ b/openadmet/models/tests/unit/comparison/test_comparison.py
@@ -81,8 +81,8 @@ def test_posthoc_comparison():
     levene, tukeys_df = comp_obj.compare(
         model_stats_fns=model_stats, labels=model_tags, task_names=task_tags
     )
-    assert_almost_equal(levene["mse"][0], 1.2975061710820235)
-    assert_almost_equal(levene["ktau"][0], 0.8835355632672074)
+    assert_almost_equal(levene["mse"]["stat"], 1.2975061710820235)
+    assert_almost_equal(levene["ktau"]["stat"], 0.8835355632672074)
     assert_almost_equal(tukeys_df["metric_val"][0], 0.10937620875054632)
     assert_almost_equal(tukeys_df["pvalue"][14], 0.00321143)
 
@@ -130,8 +130,8 @@ def test_posthoc_comparison_json_reader():
     levene, tukeys_df = comp_obj.compare(
         model_stats_fns=model_stats, labels=model_tags, task_names=task_tags
     )
-    assert levene["mse"][0] == 2.483488460351842
-    assert levene["ktau"][0] == 1.0392615736603197
+    assert levene["mse"]["stat"] == 2.483488460351842
+    assert levene["ktau"]["stat"] == 1.0392615736603197
     assert tukeys_df["metric_val"][0] == -0.01037444780666702
     assert tukeys_df["pvalue"][0] == 0.2488307785417857
 


### PR DESCRIPTION
## Description

pandas 3.0 raises TypeError when assigning strings ('***', '**', '*', '') into a float64 DataFrame column. Cast significance DataFrame to object dtype before masked string assignment.

pandas 3.0 also preserves dict keys as the row index when a dict is assigned to a column. levene_test built each column as {'stat': ..., 'pvalue': ...}, so the index changed from [0, 1] to ['stat', 'pvalue']. Update tests to use explicit label-based access (levene[metric]['stat']) rather than positional.

## Quality Assurance & AI Policy
To maintain project quality and respect maintainer bandwidth, please confirm the following:

- [x] **Manual Verification:** I have manually reviewed and tested the code in this PR.
- [x] **AI-Assisted Content:** If AI tools were used (e.g., Copilot, ChatGPT), I have personally verified the logic, edge cases, and compliance with the existing codebase. I confirm the code is not a "blind" AI generation.
- [x] **Minimal Review:** I believe this PR is in a state that requires minimal intervention or correction from maintainers.
- [x] **Scoped Change:** This PR addresses a single, well-scoped issue rather than multiple unrelated changes.

## Status
- [x] Ready to go (Checking this signals to maintainers that the PR is ready for final review)

## Developers Certificate of Origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenADMET/openadmet_toolkit/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.

---
**Note to Contributors:** We reserve the right to close PRs without review if they appear to lack human validation or do not meet the quality standards described in our `CONTRIBUTING.md`.
