### PR TITLE
Strengthen unit test suite across eval, features, inference, models, split, and CLI

### DIFF
--- a/openadmet/models/_registry_loader.py
+++ b/openadmet/models/_registry_loader.py
@@ -31,6 +31,7 @@ _FEATURIZERS = [
     "openadmet.models.features.combine",
     "openadmet.models.features.molfeat_fingerprint",
     "openadmet.models.features.molfeat_properties",
+    "openadmet.models.features.null_featurizer",
 ]
 
 _SPLITTERS = [

--- a/openadmet/models/comparison/posthoc.py
+++ b/openadmet/models/comparison/posthoc.py
@@ -220,7 +220,9 @@ class PostHocComparison(ComparisonBase):
             plot_data["normality"] = self.normality_plots(df, output_dir)
             plot_data["anova"] = self.anova(df, labels, output_dir)
             plot_data["mcs"] = self.mcs_plots(df, labels, output_dir)
-            plot_data["mean_diff"] = self.mean_diff_plots(df, labels, self.cl, output_dir)
+            plot_data["mean_diff"] = self.mean_diff_plots(
+                df, labels, self.cl, output_dir
+            )
             plot_data["paired"] = self.paired_plots(df, labels, output_dir)
 
         self.print_table(stats_dfs[0], stats_dfs[1])

--- a/openadmet/models/comparison/posthoc.py
+++ b/openadmet/models/comparison/posthoc.py
@@ -216,11 +216,12 @@ class PostHocComparison(ComparisonBase):
             self.stats_to_json(stats_dfs, output_dir=output_dir)
 
         plot_data = {}
-        plot_data["normality"] = self.normality_plots(df, output_dir)
-        plot_data["anova"] = self.anova(df, labels, output_dir)
-        plot_data["mcs"] = self.mcs_plots(df, labels, output_dir)
-        plot_data["mean_diff"] = self.mean_diff_plots(df, labels, self.cl, output_dir)
-        plot_data["paired"] = self.paired_plots(df, labels, output_dir)
+        if output_dir:
+            plot_data["normality"] = self.normality_plots(df, output_dir)
+            plot_data["anova"] = self.anova(df, labels, output_dir)
+            plot_data["mcs"] = self.mcs_plots(df, labels, output_dir)
+            plot_data["mean_diff"] = self.mean_diff_plots(df, labels, self.cl, output_dir)
+            plot_data["paired"] = self.paired_plots(df, labels, output_dir)
 
         self.print_table(stats_dfs[0], stats_dfs[1])
         self.report(stats_dfs, report, output_dir)

--- a/openadmet/models/eval/regression.py
+++ b/openadmet/models/eval/regression.py
@@ -469,7 +469,7 @@ class RegressionPlots(EvalBase):
             t_label = target_labels[task_id]
 
             if self.do_stats:
-                rm = RegressionMetrics()
+                rm = RegressionMetrics(n_resamples=self.n_resamples)
                 rm.evaluate(
                     t_true.reshape(-1, 1),
                     t_pred.reshape(-1, 1),

--- a/openadmet/models/features/null_featurizer.py
+++ b/openadmet/models/features/null_featurizer.py
@@ -1,0 +1,46 @@
+"""Null (passthrough) featurizer for lightweight testing."""
+
+from collections.abc import Iterable
+from typing import ClassVar
+
+import numpy as np
+
+from openadmet.models.features.feature_base import FeaturizerBase, featurizers
+
+
+@featurizers.register("NullFeaturizer")
+class NullFeaturizer(FeaturizerBase):
+    """
+    Null featurizer that returns a zero-filled feature matrix.
+
+    Produces a single zero feature per molecule and returns the full index array.
+    Useful for unit testing with DummyRegressorModel where feature values are irrelevant.
+
+    Attributes
+    ----------
+    type : ClassVar[str]
+        The type of the featurizer.
+
+    """
+
+    type: ClassVar[str] = "NullFeaturizer"
+
+    def featurize(self, smiles: Iterable[str]) -> tuple[np.ndarray, np.ndarray]:
+        """
+        Return zero features for all input SMILES.
+
+        Parameters
+        ----------
+        smiles : Iterable[str]
+            List or iterable of SMILES strings.
+
+        Returns
+        -------
+        tuple
+            Tuple of (features, indices). Features is a 2D array of shape (n, 1)
+            filled with zeros; indices is a 1D array of integers 0..n-1.
+
+        """
+        smiles_list = list(smiles)
+        n = len(smiles_list)
+        return np.zeros((n, 1), dtype=np.float32), np.arange(n)

--- a/openadmet/models/registries.py
+++ b/openadmet/models/registries.py
@@ -32,6 +32,7 @@ from openadmet.models.features.chemprop import *  # noqa: F401 F403
 from openadmet.models.features.combine import *  # noqa: F401 F403
 from openadmet.models.features.molfeat_fingerprint import *  # noqa: F401 F403
 from openadmet.models.features.molfeat_properties import *  # noqa: F401 F403
+from openadmet.models.features.null_featurizer import *  # noqa: F401 F403
 from openadmet.models.features.feature_base import featurizers  # noqa: F401 F403
 
 # util

--- a/openadmet/models/tests/unit/anvil/test_specification.py
+++ b/openadmet/models/tests/unit/anvil/test_specification.py
@@ -20,7 +20,7 @@ from openadmet.models.anvil.specification import (
     TransformSpec,
 )
 from openadmet.models.anvil.workflow import AnvilDeepLearningWorkflow, AnvilWorkflow
-from openadmet.models.architecture.model_base import LightningModelBase
+from openadmet.models.tests.unit import datafiles
 
 # --- DataSpec Tests ---
 
@@ -445,19 +445,12 @@ def test_anvilspecification_to_workflow_returns_correct_driver_type():
     }
 
 
-def test_anvilspecification_run_writes_provenance_to_resolved_output_dir(
-    tmp_path, mocker
-):
+def test_anvilspecification_run_writes_provenance_to_resolved_output_dir(tmp_path):
     """Test that run() writes provenance YAML files to the resolved output directory.
 
-    The system under test is the provenance-writing logic that executes *after*
-    workflow.run() returns — i.e. to_recipe() and to_multi_yaml(). Patching
-    to_workflow() is appropriate: it is the boundary between specification and
-    training, and real workflow execution requires data, featurizers, and a trained
-    model, all orthogonal to provenance writing. create_autospec is used (rather
-    than a plain Mock) so that any rename of resolved_output_dir or run() on
-    AnvilWorkflow will cause this test to fail, keeping the mock honest to the
-    real interface.
+    Uses a NullFeaturizer + DummyRegressorModel spec for a real end-to-end run,
+    verifying both the provenance-writing logic and the to_workflow() path that
+    resolves the output directory.
     """
     spec = AnvilSpecification(
         metadata=Metadata(
@@ -471,38 +464,29 @@ def test_anvilspecification_run_writes_provenance_to_resolved_output_dir(
             biotargets=[],
             tags=[],
         ),
-        data=DataSpec(type="csv", resource="d.csv", input_col="s", target_cols="t"),
+        data=DataSpec(type="csv", resource=datafiles.test_csv, input_col="SMILES", target_cols=["data1"]),
         procedure=ProcedureSpec(
-            split=SplitSpec(type="S"),
-            feat=FeatureSpec(type="F"),
-            model=ModelSpec(type="M"),
+            split=SplitSpec(type="ShuffleSplitter"),
+            feat=FeatureSpec(type="NullFeaturizer"),
+            model=ModelSpec(type="DummyRegressorModel"),
             train=TrainerSpec(type="SKLearnBasicTrainer"),
         ),
         report=ReportSpec(eval=[]),
-    )
-
-    mock_workflow = mocker.create_autospec(AnvilWorkflow, instance=True)
-    mock_workflow.resolved_output_dir = tmp_path / "resolved"
-    mock_workflow.run.return_value = None
-
-    mocker.patch.object(
-        AnvilSpecification, "to_workflow", autospec=True, return_value=mock_workflow
     )
 
     spec.run(output_dir=tmp_path / "out")
 
     # Check that provenance files were written
-    assert (tmp_path / "resolved" / "anvil_recipe.yaml").exists()
-    assert (tmp_path / "resolved" / "recipe_components" / "metadata.yaml").exists()
+    assert (tmp_path / "out" / "anvil_recipe.yaml").exists()
+    assert (tmp_path / "out" / "recipe_components" / "metadata.yaml").exists()
 
 
-def test_anvilspecification_run_tag_override(tmp_path, mocker):
+def test_anvilspecification_run_tag_override(tmp_path):
     """Test that providing a tag to run() overrides the metadata tag in provenance.
 
-    Same mocking rationale as
-    test_anvilspecification_run_writes_provenance_to_resolved_output_dir:
-    to_workflow() is patched with a create_autospec mock to skip training while
-    keeping the mock interface-honest to AnvilWorkflow.
+    Uses a NullFeaturizer + DummyRegressorModel spec so the full run() executes
+    end-to-end, verifying both the tag-override logic and that the original spec
+    object is not mutated.
     """
     spec = AnvilSpecification(
         metadata=Metadata(
@@ -516,26 +500,20 @@ def test_anvilspecification_run_tag_override(tmp_path, mocker):
             biotargets=[],
             tags=[],
         ),
-        data=DataSpec(type="csv", resource="d.csv", input_col="s", target_cols="t"),
+        data=DataSpec(type="csv", resource=datafiles.test_csv, input_col="SMILES", target_cols=["data1"]),
         procedure=ProcedureSpec(
-            split=SplitSpec(type="S"),
-            feat=FeatureSpec(type="F"),
-            model=ModelSpec(type="M"),
+            split=SplitSpec(type="ShuffleSplitter"),
+            feat=FeatureSpec(type="NullFeaturizer"),
+            model=ModelSpec(type="DummyRegressorModel"),
             train=TrainerSpec(type="SKLearnBasicTrainer"),
         ),
         report=ReportSpec(eval=[]),
     )
 
-    mock_workflow = mocker.create_autospec(AnvilWorkflow, instance=True)
-    mock_workflow.resolved_output_dir = tmp_path / "resolved"
-    mocker.patch.object(
-        AnvilSpecification, "to_workflow", autospec=True, return_value=mock_workflow
-    )
-
     spec.run(output_dir=tmp_path / "out", tag="new_tag")
 
     # Check the saved yaml has the new tag
-    saved_yaml = tmp_path / "resolved" / "anvil_recipe.yaml"
+    saved_yaml = tmp_path / "out" / "anvil_recipe.yaml"
     with open(saved_yaml) as f:
         saved_data = yaml.safe_load(f)
     assert saved_data["metadata"]["tag"] == "new_tag"
@@ -616,42 +594,33 @@ def test_dataspec_read_train_test_yaml_raises():
 # --- ModelSpec freeze_weights tests (Refinement 6) ---
 
 
-def test_modelspec_freeze_weights_succeeds_when_supported(mocker):
-    """Test ModelSpec instantiates without error when freeze_weights is supported.
+@pytest.mark.parametrize(
+    "freeze_config",
+    [
+        {"message_passing": True},
+        {"batch_norm": True},
+        {"message_passing": True, "batch_norm": True},
+        {"message_passing": True, "batch_norm": True, "ffn_layers": 1},
+    ],
+)
+def test_modelspec_freeze_weights_succeeds_when_supported(freeze_config):
+    """Test ModelSpec instantiates without error for each valid ChemPropModel freeze configuration.
 
-    create_autospec(LightningModelBase) is used rather than a real model because
-    the validator calls build() and freeze_weights() as a side-effect probe during
-    construction. A real ChemPropModel.build() constructs a full MPNN, which is
-    heavyweight and orthogonal to what is being tested. The mock enforces the
-    LightningModelBase interface while keeping the test fast and focused on the
-    validator logic in ModelSpec.
+    Parametrizes over all supported freeze_weights combinations. The validator calls
+    build() + freeze_weights() (with no args) as a side-effect probe during construction;
+    passing means the model supports weight freezing. ChemPropModel.build() takes ~6ms
+    and freeze_weights() is instantaneous.
     """
-    mock_model = mocker.create_autospec(LightningModelBase, instance=True)
-    mock_model.build.return_value = None
-    mock_model.freeze_weights.return_value = None
-
-    mocker.patch.object(ModelSpec, "to_class", autospec=True, return_value=mock_model)
-
-    spec = ModelSpec(type="SomeModel", freeze_weights={"layer": "encoder"})
+    spec = ModelSpec(type="ChemPropModel", freeze_weights=freeze_config)
     assert spec is not None
-    mock_model.build.assert_called_once()
-    mock_model.freeze_weights.assert_called_once()
 
 
-def test_modelspec_freeze_weights_raises_when_not_implemented(mocker):
+def test_modelspec_freeze_weights_raises_when_not_implemented():
     """Test ModelSpec raises ValueError when freeze_weights is not implemented.
 
-    Same rationale as test_modelspec_freeze_weights_succeeds_when_supported:
-    create_autospec enforces the LightningModelBase interface. freeze_weights
-    raising NotImplementedError is a base-class contract; no concrete model
-    needs to be instantiated to test that ModelSpec translates it into a
-    ValueError.
+    NeuralPairwiseRegressorModel inherits LightningModelBase.freeze_weights() which
+    raises NotImplementedError. The validator translates this to ValueError so that
+    misconfigured recipes fail at parse time rather than at training time.
     """
-    mock_model = mocker.create_autospec(LightningModelBase, instance=True)
-    mock_model.build.return_value = None
-    mock_model.freeze_weights.side_effect = NotImplementedError("not implemented")
-
-    mocker.patch.object(ModelSpec, "to_class", autospec=True, return_value=mock_model)
-
     with pytest.raises(ValueError, match="Weight freezing not implemented"):
-        ModelSpec(type="SomeModel", freeze_weights={"layer": "encoder"})
+        ModelSpec(type="NeuralPairwiseRegressorModel", freeze_weights={"message_passing": True})

--- a/openadmet/models/tests/unit/anvil/test_specification.py
+++ b/openadmet/models/tests/unit/anvil/test_specification.py
@@ -464,7 +464,12 @@ def test_anvilspecification_run_writes_provenance_to_resolved_output_dir(tmp_pat
             biotargets=[],
             tags=[],
         ),
-        data=DataSpec(type="csv", resource=datafiles.test_csv, input_col="SMILES", target_cols=["data1"]),
+        data=DataSpec(
+            type="csv",
+            resource=datafiles.test_csv,
+            input_col="SMILES",
+            target_cols=["data1"],
+        ),
         procedure=ProcedureSpec(
             split=SplitSpec(type="ShuffleSplitter"),
             feat=FeatureSpec(type="NullFeaturizer"),
@@ -500,7 +505,12 @@ def test_anvilspecification_run_tag_override(tmp_path):
             biotargets=[],
             tags=[],
         ),
-        data=DataSpec(type="csv", resource=datafiles.test_csv, input_col="SMILES", target_cols=["data1"]),
+        data=DataSpec(
+            type="csv",
+            resource=datafiles.test_csv,
+            input_col="SMILES",
+            target_cols=["data1"],
+        ),
         procedure=ProcedureSpec(
             split=SplitSpec(type="ShuffleSplitter"),
             feat=FeatureSpec(type="NullFeaturizer"),
@@ -623,4 +633,7 @@ def test_modelspec_freeze_weights_raises_when_not_implemented():
     misconfigured recipes fail at parse time rather than at training time.
     """
     with pytest.raises(ValueError, match="Weight freezing not implemented"):
-        ModelSpec(type="NeuralPairwiseRegressorModel", freeze_weights={"message_passing": True})
+        ModelSpec(
+            type="NeuralPairwiseRegressorModel",
+            freeze_weights={"message_passing": True},
+        )

--- a/openadmet/models/tests/unit/cli/test_cli.py
+++ b/openadmet/models/tests/unit/cli/test_cli.py
@@ -43,7 +43,9 @@ def test_predict_cli_invokes_inference(tmp_path, runner, mocker):
     model_dir = tmp_path / "model_dir"
     model_dir.mkdir()
 
-    mock_inference = mocker.patch.object(predict_cli_module, "inference_func", autospec=True)
+    mock_inference = mocker.patch.object(
+        predict_cli_module, "inference_func", autospec=True
+    )
 
     result = runner.invoke(
         cli,
@@ -77,9 +79,14 @@ def test_anvil_cli_invokes_workflow(tmp_path, runner, mocker):
     We mock the `AnvilSpecification` and workflow execution to verify that the CLI correctly handles
     recipe paths and output directories without actually running a full ML training job.
     """
-    mock_spec = mocker.create_autospec(anvil_cli_module.AnvilSpecification, instance=True)
+    mock_spec = mocker.create_autospec(
+        anvil_cli_module.AnvilSpecification, instance=True
+    )
     mock_from_recipe = mocker.patch.object(
-        anvil_cli_module.AnvilSpecification, "from_recipe", autospec=True, return_value=mock_spec
+        anvil_cli_module.AnvilSpecification,
+        "from_recipe",
+        autospec=True,
+        return_value=mock_spec,
     )
 
     result = runner.invoke(

--- a/openadmet/models/tests/unit/cli/test_cli.py
+++ b/openadmet/models/tests/unit/cli/test_cli.py
@@ -1,59 +1,87 @@
-from openadmet.models.cli.cli import cli
-from openadmet.models.tests.test_utils import click_success
-from openadmet.models.tests.unit.datafiles import (
-    anvil_lgbm_trained_model_dir,
-    pred_test_data_csv,
-    basic_anvil_yaml_cv,
-)
+from pathlib import Path
+
 import pytest
 from click.testing import CliRunner
 
+from openadmet.models.cli import anvil as anvil_cli_module
+from openadmet.models.cli import predict as predict_cli_module
+from openadmet.models.cli.cli import cli
+from openadmet.models.tests.test_utils import click_success
+from openadmet.models.tests.unit.datafiles import basic_anvil_yaml_cv
 
-def test_toplevel_runnable():
-    """Test the top-level CLI command"""
-    runner = CliRunner()
+
+@pytest.fixture
+def runner():
+    """Provide a Click CliRunner for testing CLI commands in isolation."""
+    return CliRunner()
+
+
+def test_toplevel_runnable(runner):
+    """Ensure the top-level 'openadmet' command runs and displays help without error."""
     result = runner.invoke(cli, ["--help"])
     assert click_success(result)
 
 
 @pytest.mark.parametrize(
-    "args",
-    [
-        ["anvil", "--help"],
-        ["compare", "--help"],
-        ["predict", "--help"],
-    ],
+    "args", [["anvil", "--help"], ["compare", "--help"], ["predict", "--help"]]
 )
-def test_subcommand_runnable(args):
-    """Test the subcommands"""
-    runner = CliRunner()
+def test_subcommand_runnable(runner, args):
+    """Verify that all major subcommands (anvil, compare, predict) are registered and runnable."""
     result = runner.invoke(cli, args)
     assert click_success(result)
 
 
-def test_predict_cli(tmp_path):
-    """Test the predict CLI command"""
-    runner = CliRunner()
+def test_predict_cli_invokes_inference(tmp_path, runner, mocker):
+    """
+    Validate that the 'predict' subcommand correctly parses arguments and calls the underlying inference function.
+
+    We mock `inference_func` to avoid loading real models (which is heavy and requires trained artifacts).
+    This ensures that the CLI layer correctly passes paths, column names, and flags to the logic layer.
+    """
+    input_csv = tmp_path / "input.csv"
+    input_csv.write_text("MY_SMILES\nCCO\n")
+    model_dir = tmp_path / "model_dir"
+    model_dir.mkdir()
+
+    mock_inference = mocker.patch.object(predict_cli_module, "inference_func")
+
     result = runner.invoke(
         cli,
         [
             "predict",
             "--input-path",
-            pred_test_data_csv,
+            input_csv,
             "--input-col",
             "MY_SMILES",
             "--model-dir",
-            anvil_lgbm_trained_model_dir,
+            model_dir,
             "--output-csv",
             tmp_path / "predictions.csv",
+            "--accelerator",
+            "cpu",
         ],
     )
     assert click_success(result)
+    mock_inference.assert_called_once()
+    called = mock_inference.call_args.kwargs
+    assert called["input_col"] == "MY_SMILES"
+    assert called["accelerator"] == "cpu"
+    assert called["write_csv"] is True
+    assert list(called["model_dir"]) == [model_dir]
 
 
-def test_anvil_cli(tmp_path):
-    """Test the anvil CLI command"""
-    runner = CliRunner()
+def test_anvil_cli_invokes_workflow(tmp_path, runner, mocker):
+    """
+    Validate that the 'anvil' subcommand correctly initializes and runs a workflow from a recipe.
+
+    We mock the `AnvilSpecification` and workflow execution to verify that the CLI correctly handles
+    recipe paths and output directories without actually running a full ML training job.
+    """
+    mock_spec = mocker.Mock()
+    mock_from_recipe = mocker.patch.object(
+        anvil_cli_module.AnvilSpecification, "from_recipe", return_value=mock_spec
+    )
+
     result = runner.invoke(
         cli,
         [
@@ -66,3 +94,48 @@ def test_anvil_cli(tmp_path):
     )
 
     assert click_success(result)
+    mock_from_recipe.assert_called_once_with(basic_anvil_yaml_cv)
+    mock_spec.run.assert_called_once()
+    called = mock_spec.run.call_args.kwargs
+    assert Path(called["output_dir"]) == tmp_path / "anvil_output"
+    assert called["debug"] is False
+
+
+@pytest.mark.parametrize(
+    "aq_fxns,beta,best_y,xi,expected",
+    [
+        (("ucb",), (2.0,), (), (), {"ucb": {"beta": 2.0}}),
+        (
+            ("ei", "pi"),
+            (),
+            (1.0, 2.0),
+            (0.1, 0.2),
+            {"ei": {"xi": 0.1, "best_y": 1.0}, "pi": {"xi": 0.2, "best_y": 2.0}},
+        ),
+    ],
+)
+def test_validate_aq_fxns_success(aq_fxns, beta, best_y, xi, expected):
+    """
+    Verify that valid combinations of acquisition function arguments are correctly parsed into a configuration dict.
+
+    This tests the CLI argument validation logic for active learning parameters.
+    """
+    assert predict_cli_module._validate_aq_fxns(aq_fxns, beta, best_y, xi) == expected
+
+
+@pytest.mark.parametrize(
+    "aq_fxns,beta,best_y,xi,error_message",
+    [
+        (("ucb", "ucb"), (1.0, 2.0), (), (), "UCB can only be specified once"),
+        (("ei",), (), (), (), "must be specified once per EI and/or PI acquisition"),
+        (("ucb",), (), (), (), "Field `beta` must be specified for UCB acquisition"),
+    ],
+)
+def test_validate_aq_fxns_errors(aq_fxns, beta, best_y, xi, error_message):
+    """
+    Ensure that invalid acquisition function arguments trigger appropriate validation errors.
+
+    This prevents users from running predictions with ambiguous or incomplete active learning settings.
+    """
+    with pytest.raises(ValueError, match=error_message):
+        predict_cli_module._validate_aq_fxns(aq_fxns, beta, best_y, xi)

--- a/openadmet/models/tests/unit/cli/test_cli.py
+++ b/openadmet/models/tests/unit/cli/test_cli.py
@@ -1,13 +1,13 @@
 from pathlib import Path
 
+import pandas as pd
 import pytest
 from click.testing import CliRunner
 
-from openadmet.models.cli import anvil as anvil_cli_module
 from openadmet.models.cli import predict as predict_cli_module
 from openadmet.models.cli.cli import cli
 from openadmet.models.tests.test_utils import click_success
-from openadmet.models.tests.unit.datafiles import basic_anvil_yaml_cv
+from openadmet.models.tests.unit.datafiles import dummy_null_anvil_yaml
 
 
 @pytest.fixture
@@ -31,81 +31,64 @@ def test_subcommand_runnable(runner, args):
     assert click_success(result)
 
 
-def test_predict_cli_invokes_inference(tmp_path, runner, mocker):
+def test_predict_cli_invokes_inference(tmp_path, runner, null_single_model_dir):
     """
-    Validate that the 'predict' subcommand correctly parses arguments and calls the underlying inference function.
+    Validate that the 'predict' subcommand runs inference end-to-end and writes predictions.
 
-    We mock `inference_func` to avoid loading real models (which is heavy and requires trained artifacts).
-    This ensures that the CLI layer correctly passes paths, column names, and flags to the logic layer.
+    Uses a real NullFeaturizer + DummyRegressorModel fixture so that the CLI path,
+    featurization, and prediction logic all execute without mocking any layer.
     """
     input_csv = tmp_path / "input.csv"
     input_csv.write_text("MY_SMILES\nCCO\n")
-    model_dir = tmp_path / "model_dir"
-    model_dir.mkdir()
-
-    mock_inference = mocker.patch.object(
-        predict_cli_module, "inference_func", autospec=True
-    )
+    output_csv = tmp_path / "predictions.csv"
 
     result = runner.invoke(
         cli,
         [
             "predict",
             "--input-path",
-            input_csv,
+            str(input_csv),
             "--input-col",
             "MY_SMILES",
             "--model-dir",
-            model_dir,
+            str(null_single_model_dir),
             "--output-csv",
-            tmp_path / "predictions.csv",
+            str(output_csv),
             "--accelerator",
             "cpu",
         ],
     )
     assert click_success(result)
-    mock_inference.assert_called_once()
-    called = mock_inference.call_args.kwargs
-    assert called["input_col"] == "MY_SMILES"
-    assert called["accelerator"] == "cpu"
-    assert called["write_csv"] is True
-    assert list(called["model_dir"]) == [model_dir]
+    assert output_csv.exists()
+    df = pd.read_csv(output_csv)
+    assert "OADMET_PRED_UNIT_task_0" in df.columns
+    assert "OADMET_STD_UNIT_task_0" in df.columns
 
 
-def test_anvil_cli_invokes_workflow(tmp_path, runner, mocker):
+def test_anvil_cli_invokes_workflow(tmp_path, runner):
     """
-    Validate that the 'anvil' subcommand correctly initializes and runs a workflow from a recipe.
+    Validate that the 'anvil' subcommand runs a lightweight workflow end-to-end.
 
-    We mock the `AnvilSpecification` and workflow execution to verify that the CLI correctly handles
-    recipe paths and output directories without actually running a full ML training job.
+    Uses the dummy_null_anvil recipe (NullFeaturizer + DummyRegressorModel) so the full
+    parse → train → save pipeline executes without mocking any layer.
     """
-    mock_spec = mocker.create_autospec(
-        anvil_cli_module.AnvilSpecification, instance=True
-    )
-    mock_from_recipe = mocker.patch.object(
-        anvil_cli_module.AnvilSpecification,
-        "from_recipe",
-        autospec=True,
-        return_value=mock_spec,
-    )
+    output_dir = tmp_path / "anvil_output"
 
     result = runner.invoke(
         cli,
         [
             "anvil",
             "--recipe-path",
-            basic_anvil_yaml_cv,
+            dummy_null_anvil_yaml,
             "--output-dir",
-            tmp_path / "anvil_output",
+            str(output_dir),
         ],
     )
 
     assert click_success(result)
-    mock_from_recipe.assert_called_once_with(basic_anvil_yaml_cv)
-    mock_spec.run.assert_called_once()
-    called = mock_spec.run.call_args.kwargs
-    assert Path(called["output_dir"]) == tmp_path / "anvil_output"
-    assert called["debug"] is False
+    assert output_dir.exists()
+    assert (output_dir / "model.pkl").exists()
+    assert (output_dir / "recipe_components").is_dir()
 
 
 @pytest.mark.parametrize(

--- a/openadmet/models/tests/unit/cli/test_cli.py
+++ b/openadmet/models/tests/unit/cli/test_cli.py
@@ -43,7 +43,7 @@ def test_predict_cli_invokes_inference(tmp_path, runner, mocker):
     model_dir = tmp_path / "model_dir"
     model_dir.mkdir()
 
-    mock_inference = mocker.patch.object(predict_cli_module, "inference_func")
+    mock_inference = mocker.patch.object(predict_cli_module, "inference_func", autospec=True)
 
     result = runner.invoke(
         cli,
@@ -77,9 +77,9 @@ def test_anvil_cli_invokes_workflow(tmp_path, runner, mocker):
     We mock the `AnvilSpecification` and workflow execution to verify that the CLI correctly handles
     recipe paths and output directories without actually running a full ML training job.
     """
-    mock_spec = mocker.Mock()
+    mock_spec = mocker.create_autospec(anvil_cli_module.AnvilSpecification, instance=True)
     mock_from_recipe = mocker.patch.object(
-        anvil_cli_module.AnvilSpecification, "from_recipe", return_value=mock_spec
+        anvil_cli_module.AnvilSpecification, "from_recipe", autospec=True, return_value=mock_spec
     )
 
     result = runner.invoke(

--- a/openadmet/models/tests/unit/comparison/test_comparison.py
+++ b/openadmet/models/tests/unit/comparison/test_comparison.py
@@ -1,26 +1,32 @@
+import numpy as np
 import pytest
 from numpy.testing import assert_almost_equal
-import numpy as np
+
 from openadmet.models.comparison.compare_base import get_comparison_class
 from openadmet.models.comparison.posthoc import PostHocComparison
 from openadmet.models.tests.unit.datafiles import (
-    cyp2c9_json,
+    anvil_lgbm_trained_model_dir,
     cyp1a2_json,
+    cyp2c9_json,
     cyp3a4_json,
     multi_task_json,
-    anvil_lgbm_trained_model_dir,
 )
 
 
 def test_get_comparison_class():
-    """Test getting comparison class."""
+    """
+    Test dynamic retrieval of comparison classes from the registry.
+
+    Verifies that valid class names return the class and invalid names raise ValueError.
+    """
     get_comparison_class("PostHoc")
     with pytest.raises(ValueError):
         get_comparison_class("NotARealClass")
 
 
 def test_posthoc_fails_on_incorrect_inputs():
-    """Test that posthoc comparison fails when given incorrect inputs.
+    """
+    Test that posthoc comparison fails when given incorrect inputs.
 
     Inputs include:
     - No inputs
@@ -28,6 +34,8 @@ def test_posthoc_fails_on_incorrect_inputs():
     - Mismatched lengths of model_stats_fns, labels, and task_names
     - Repeated labels
     - Incorrect labels and task_names for model_stats_fns
+
+    This validation is critical to ensure that comparison tables and plots match models to their correct metadata.
     """
     comp_obj = PostHocComparison()
     with pytest.raises(ValueError):
@@ -69,7 +77,12 @@ def test_posthoc_repeat_label_error():
 
 
 def test_posthoc_comparison():
-    """Test that posthoc comparison works when given correct inputs."""
+    """
+    Test that posthoc comparison works correctly when given valid inputs.
+
+    This verifies the calculation of statistical tests (Levene's test for equality of variances,
+    Tukey's HSD for pairwise mean differences) based on loaded model metrics.
+    """
     model_stats = [cyp2c9_json, cyp3a4_json, cyp1a2_json]
     model_tags = [
         "openadmet-CYP2C9-pchembl-regression-testing-cv",
@@ -97,7 +110,12 @@ def test_posthoc_comparison():
 def test_posthoc_comparison_anvil_reader_and_feature_label(
     label_types, expected_labels
 ):
-    """Test that posthoc comparison can read from anvil-trained model directories and features."""
+    """
+    Test that posthoc comparison can automatically extract labels from anvil-trained model directories.
+
+    This ensures that metadata stored in `metadata.yaml` within model directories can be correctly
+    parsed to generate readable labels for comparison plots.
+    """
     comp_obj = PostHocComparison()
     model_stats_fns, labels, task_names = comp_obj.label_and_task_name_from_anvil(
         model_dirs=[anvil_lgbm_trained_model_dir], label_types=label_types
@@ -121,7 +139,12 @@ def test_posthoc_comparison_json_reader_fails(label_types):
 
 
 def test_posthoc_comparison_json_reader():
-    """Test that posthoc comparison can read multi vs single task from anvil file."""
+    """
+    Test that posthoc comparison handles both multi-task and single-task JSON result files.
+
+    This verifies that the system can normalize results from different task types into a common
+    format for statistical comparison.
+    """
     model_stats = [multi_task_json, cyp3a4_json]
     model_tags = ["multitask", "single_task"]
     task_tags = ["cyp3a4_pchembl_value_mean", "pchembl_value_mean"]
@@ -130,14 +153,18 @@ def test_posthoc_comparison_json_reader():
     levene, tukeys_df = comp_obj.compare(
         model_stats_fns=model_stats, labels=model_tags, task_names=task_tags
     )
-    assert levene["mse"]["stat"] == 2.483488460351842
-    assert levene["ktau"]["stat"] == 1.0392615736603197
-    assert tukeys_df["metric_val"][0] == -0.01037444780666702
-    assert tukeys_df["pvalue"][0] == 0.2488307785417857
+    assert np.allclose(levene["mse"]["stat"], 2.483488460351842)
+    assert np.allclose(levene["ktau"]["stat"], 1.0392615736603197)
+    assert np.allclose(tukeys_df["metric_val"][0], -0.01037444780666702)
+    assert np.allclose(tukeys_df["pvalue"][0], 0.2488307785417857)
 
 
 def test_posthoc_comparison_printing(capsys):
-    """Test that posthoc comparison prints results to console."""
+    """
+    Test that posthoc comparison prints results to console in a readable format.
+
+    We capture stdout to verify that Levene's test and Tukey's HSD results are actually displayed to the user.
+    """
     model_stats = [cyp2c9_json, cyp3a4_json, cyp1a2_json]
     model_tags = [
         "openadmet-CYP2C9-pchembl-regression-testing-cv",

--- a/openadmet/models/tests/unit/conftest.py
+++ b/openadmet/models/tests/unit/conftest.py
@@ -1,0 +1,97 @@
+"""Session-scoped fixtures providing lightweight on-disk model directories for unit tests."""
+
+import yaml
+import numpy as np
+import pytest
+
+from openadmet.models.architecture.dummy import DummyRegressorModel
+
+
+def _write_recipe_components(recipe_dir, tag, ensemble=False):
+    """Write the three required YAML files into a recipe_components directory."""
+    recipe_dir.mkdir(parents=True, exist_ok=True)
+
+    metadata = {
+        "version": "v1",
+        "driver": "sklearn",
+        "name": "unit-test",
+        "build_number": 0,
+        "description": "Unit test model",
+        "tag": tag,
+        "authors": "Test Author",
+        "email": "test@test.com",
+        "biotargets": ["test"],
+        "tags": ["test"],
+    }
+    with open(recipe_dir / "metadata.yaml", "w") as f:
+        yaml.safe_dump(metadata, f)
+
+    data_spec = {
+        "type": "csv",
+        "input_col": "MY_SMILES",
+        "target_cols": ["task_0"],
+    }
+    with open(recipe_dir / "data.yaml", "w") as f:
+        yaml.safe_dump(data_spec, f)
+
+    procedure = {
+        "feat": {"type": "NullFeaturizer", "params": {}},
+        "model": {"type": "DummyRegressorModel", "params": {}},
+        "split": {
+            "type": "ShuffleSplitter",
+            "params": {"train_size": 0.8, "test_size": 0.2, "random_state": 42},
+        },
+        "train": {"type": "SKLearnBasicTrainer", "params": {}},
+    }
+    if ensemble:
+        procedure["ensemble"] = {"type": "CommitteeRegressor", "n_models": 2, "params": {}}
+
+    with open(recipe_dir / "procedure.yaml", "w") as f:
+        yaml.safe_dump(procedure, f)
+
+
+def _make_trained_dummy(constant_value):
+    """Return a DummyRegressorModel trained to always predict `constant_value`."""
+    X_train = np.zeros((3, 1))
+    y_train = np.full(3, constant_value)
+    model = DummyRegressorModel()
+    model.train(X_train, y_train)
+    return model
+
+
+@pytest.fixture(scope="session")
+def null_single_model_dir(tmp_path_factory):
+    """
+    Session-scoped on-disk model directory for a single DummyRegressorModel.
+
+    The directory contains a complete recipe_components layout plus serialized
+    model files. The model always predicts 1.0 regardless of input features
+    (tag=UNIT, target=task_0).
+    """
+    model_dir = tmp_path_factory.mktemp("null_single_model")
+    _write_recipe_components(model_dir / "recipe_components", tag="UNIT")
+
+    model = _make_trained_dummy(1.0)
+    model.serialize(model_dir / "model.json", model_dir / "model.pkl")
+
+    return model_dir
+
+
+@pytest.fixture(scope="session")
+def null_ensemble_model_dir(tmp_path_factory):
+    """
+    Session-scoped on-disk model directory for a two-member CommitteeRegressor.
+
+    Member 0 predicts 1.0 and member 1 predicts 3.0, so the ensemble mean is 2.0
+    and the standard deviation is 1.0 for any input (tag=ENS, target=task_0).
+    """
+    model_dir = tmp_path_factory.mktemp("null_ensemble_model")
+    _write_recipe_components(model_dir / "recipe_components", tag="ENS", ensemble=True)
+
+    for i, constant_value in enumerate([1.0, 3.0]):
+        member_dir = model_dir / f"model_{i}"
+        member_dir.mkdir()
+        model = _make_trained_dummy(constant_value)
+        model.serialize(member_dir / "model.json", member_dir / "model.pkl")
+
+    return model_dir

--- a/openadmet/models/tests/unit/conftest.py
+++ b/openadmet/models/tests/unit/conftest.py
@@ -44,7 +44,11 @@ def _write_recipe_components(recipe_dir, tag, ensemble=False):
         "train": {"type": "SKLearnBasicTrainer", "params": {}},
     }
     if ensemble:
-        procedure["ensemble"] = {"type": "CommitteeRegressor", "n_models": 2, "params": {}}
+        procedure["ensemble"] = {
+            "type": "CommitteeRegressor",
+            "n_models": 2,
+            "params": {},
+        }
 
     with open(recipe_dir / "procedure.yaml", "w") as f:
         yaml.safe_dump(procedure, f)

--- a/openadmet/models/tests/unit/data/test_data.py
+++ b/openadmet/models/tests/unit/data/test_data.py
@@ -5,6 +5,12 @@ from openadmet.models.tests.unit.datafiles import intake_cat, nan_data, test_csv
 
 
 def test_data_spec_from_csv():
+    """
+    Validate loading data from a CSV file via DataSpec.
+
+    Ensures that the data loader correctly reads the specified CSV, extracts the target and SMILES columns,
+    and returns them as expected.
+    """
     data_spec = DataSpec(
         type="intake",
         resource=test_csv,
@@ -18,6 +24,12 @@ def test_data_spec_from_csv():
 
 
 def test_data_spec_from_intake():
+    """
+    Validate loading data from an Intake catalog.
+
+    Intake allows for declarative data loading. This test checks that DataSpec can correctly interface
+    with an Intake catalog to retrieve data.
+    """
     data_spec = DataSpec(
         type="intake",
         resource=intake_cat,
@@ -32,6 +44,12 @@ def test_data_spec_from_intake():
 
 @pytest.mark.parametrize("dropna, expected_length", [(True, 3333), (False, 7196)])
 def test_data_spec_dropna(dropna, expected_length):
+    """
+    Test the `dropna` functionality in DataSpec.
+
+    Verifies that rows with missing values in target columns are dropped when dropna=True,
+    and preserved when dropna=False. This is critical for handling real-world datasets which often contain gaps.
+    """
     data_spec = DataSpec(
         type="intake",
         resource=nan_data,

--- a/openadmet/models/tests/unit/datafiles.py
+++ b/openadmet/models/tests/unit/datafiles.py
@@ -15,6 +15,7 @@ basic_anvil_yaml_classification = (
     _data_ref / "basic_anvil_classification.yaml"
 ).as_posix()
 tabpfn_anvil_classification_yaml = (_data_ref / "tabpfn_ache.yaml").as_posix()
+dummy_null_anvil_yaml = (_data_ref / "dummy_null_anvil.yaml").as_posix()
 
 # individual sections for multi-yaml
 metadata_yaml = (_data_ref / "basic_anvil_metadata.yaml").as_posix()

--- a/openadmet/models/tests/unit/eval/test_eval.py
+++ b/openadmet/models/tests/unit/eval/test_eval.py
@@ -1,6 +1,5 @@
 import matplotlib.figure
 import numpy as np
-import pytest
 import seaborn as sns
 
 from openadmet.models.eval.binary import PosthocBinaryMetrics
@@ -41,9 +40,9 @@ def test_regression_metrics():
     rm = RegressionMetrics(n_resamples=100)
     metrics = rm.evaluate(y_true, y_pred)
 
-    assert metrics["task_0"]["mse"]["value"] == pytest.approx(0.375, abs=0.001)
-    assert metrics["task_0"]["mae"]["value"] == pytest.approx(0.5, abs=0.001)
-    assert metrics["task_0"]["r2"]["value"] == pytest.approx(0.94860, abs=0.001)
+    assert np.allclose(metrics["task_0"]["mse"]["value"], 0.375, atol=0.001)
+    assert np.allclose(metrics["task_0"]["mae"]["value"], 0.5, atol=0.001)
+    assert np.allclose(metrics["task_0"]["r2"]["value"], 0.94860, atol=0.001)
 
 
 def test_regression_metrics_and_cv_include_rae_and_pct_within_1_log_for_pxc50():
@@ -68,7 +67,7 @@ def test_relative_absolute_error_formula():
     y_true = np.array([1.0, 2.0, 3.0])
     y_pred = np.array([1.0, 2.0, 4.0])
 
-    assert relative_absolute_error(y_true, y_pred) == pytest.approx(0.5)
+    assert np.allclose(relative_absolute_error(y_true, y_pred), 0.5)
 
 
 def test_relative_absolute_error_denominator_zero():
@@ -82,7 +81,7 @@ def test_pct_within_1_log_unit():
     y_true = np.array([6.0, 7.0, 8.0])
     y_pred = np.array([6.5, 7.2, 9.5])
 
-    assert pct_within_1_log_unit(y_true, y_pred) == pytest.approx(2 / 3)
+    assert np.allclose(pct_within_1_log_unit(y_true, y_pred), 2 / 3)
 
 
 def test_cv_rae_scorer_is_minimization():
@@ -99,7 +98,7 @@ def test_lightning_cv_pct_within_1_log_uses_raw_metric_callable():
     y_true = np.array([6.0, 7.0, 8.0])
     y_pred = np.array([6.5, 7.2, 9.5])
 
-    assert pct_within_1_log(y_true, y_pred) == pytest.approx(2 / 3)
+    assert np.allclose(pct_within_1_log(y_true, y_pred), 2 / 3)
 
 
 def test_regression_plots():
@@ -138,12 +137,12 @@ def test_classification_metrics():
     cm = ClassificationMetrics(n_resamples=100)
     metrics = cm.evaluate(y_true, y_pred)
 
-    assert metrics["accuracy"]["value"] == pytest.approx(0.75)
-    assert metrics["precision"]["value"] == pytest.approx(0.667, abs=0.001)
-    assert metrics["recall"]["value"] == pytest.approx(1.0)
-    assert metrics["f1"]["value"] == pytest.approx(0.8)
-    assert metrics["roc_auc"]["value"] == pytest.approx(0.75)
-    assert metrics["pr_auc"]["value"] == pytest.approx(0.833, abs=0.001)
+    assert np.allclose(metrics["accuracy"]["value"], 0.75)
+    assert np.allclose(metrics["precision"]["value"], 0.667, atol=0.001)
+    assert np.allclose(metrics["recall"]["value"], 1.0)
+    assert np.allclose(metrics["f1"]["value"], 0.8)
+    assert np.allclose(metrics["roc_auc"]["value"], 0.75)
+    assert np.allclose(metrics["pr_auc"]["value"], 0.833, atol=0.001)
 
 
 def test_classification_plots():

--- a/openadmet/models/tests/unit/eval/test_eval.py
+++ b/openadmet/models/tests/unit/eval/test_eval.py
@@ -111,7 +111,7 @@ def test_regression_plots():
     y_true = np.array([3, -0.5, 2, 7]).reshape(-1, 1)
     y_pred = np.array([2.5, 0.0, 2, 8]).reshape(-1, 1)
 
-    rm = RegressionPlots()
+    rm = RegressionPlots(n_resamples=100)
     plot_data = rm.evaluate(y_true, y_pred)
 
     assert isinstance(plot_data, dict)

--- a/openadmet/models/tests/unit/eval/test_eval.py
+++ b/openadmet/models/tests/unit/eval/test_eval.py
@@ -1,6 +1,8 @@
-import pytest
-
+import matplotlib.figure
 import numpy as np
+import pytest
+import seaborn as sns
+
 from openadmet.models.eval.binary import PosthocBinaryMetrics
 from openadmet.models.eval.classification import (
     ClassificationMetrics,
@@ -20,21 +22,28 @@ from openadmet.models.eval.regression import (
 
 
 def test_get_eval_class():
+    """Verify that evaluation classes can be retrieved by name from the registry."""
     get_eval_class("RegressionMetrics")
     get_eval_class("PosthocBinaryMetrics")
     get_eval_class("ClassificationMetrics")
 
 
 def test_regression_metrics():
+    """
+    Validate calculation of standard regression metrics (MSE, MAE, R2).
+
+    This test uses simple synthetic data to ensure that the mathematical implementations
+    of these metrics are correct and return the expected values.
+    """
     y_true = np.array([3, -0.5, 2, 7]).reshape(-1, 1)
     y_pred = np.array([2.5, 0.0, 2, 8]).reshape(-1, 1)
 
     rm = RegressionMetrics(n_resamples=100)
     metrics = rm.evaluate(y_true, y_pred)
 
-    assert metrics["task_0"]["mse"]["value"] == 0.375
-    assert metrics["task_0"]["mae"]["value"] == 0.5
-    assert metrics["task_0"]["r2"]["value"] == 0.9486081370449679
+    assert metrics["task_0"]["mse"]["value"] == pytest.approx(0.375, abs=0.001)
+    assert metrics["task_0"]["mae"]["value"] == pytest.approx(0.5, abs=0.001)
+    assert metrics["task_0"]["r2"]["value"] == pytest.approx(0.94860, abs=0.001)
 
 
 def test_regression_metrics_and_cv_include_rae_and_pct_within_1_log_for_pxc50():
@@ -94,16 +103,32 @@ def test_lightning_cv_pct_within_1_log_uses_raw_metric_callable():
 
 
 def test_regression_plots():
+    """
+    Verify that regression plotting functions return valid figure objects.
+
+    This ensures that regression plots (JointGrid for parity, Figure for CI) are generated
+    without error, which is important for model reporting.
+    """
     y_true = np.array([3, -0.5, 2, 7]).reshape(-1, 1)
     y_pred = np.array([2.5, 0.0, 2, 8]).reshape(-1, 1)
 
     rm = RegressionPlots()
-    rm.evaluate(y_true, y_pred)
+    plot_data = rm.evaluate(y_true, y_pred)
 
-    assert True
+    assert isinstance(plot_data, dict)
+    assert "task_0_regplot" in plot_data
+    assert "task_0_ciplot" in plot_data
+    assert isinstance(plot_data["task_0_regplot"], sns.axisgrid.JointGrid)
+    assert isinstance(plot_data["task_0_ciplot"], matplotlib.figure.Figure)
 
 
 def test_classification_metrics():
+    """
+    Validate calculation of classification metrics (Accuracy, Precision, Recall, F1, AUC).
+
+    This ensures that for binary classification tasks, the metrics are computed correctly based on
+    predicted probabilities and ground truth labels.
+    """
     y_true = [0, 1, 1, 0]
 
     # We pass probabilities of the class, not the class itself
@@ -113,25 +138,38 @@ def test_classification_metrics():
     cm = ClassificationMetrics(n_resamples=100)
     metrics = cm.evaluate(y_true, y_pred)
 
-    assert metrics["accuracy"]["value"] == 0.75
+    assert metrics["accuracy"]["value"] == pytest.approx(0.75)
     assert metrics["precision"]["value"] == pytest.approx(0.667, abs=0.001)
-    assert metrics["recall"]["value"] == 1.0
-    assert metrics["f1"]["value"] == 0.8
-    assert metrics["roc_auc"]["value"] == 0.75
+    assert metrics["recall"]["value"] == pytest.approx(1.0)
+    assert metrics["f1"]["value"] == pytest.approx(0.8)
+    assert metrics["roc_auc"]["value"] == pytest.approx(0.75)
     assert metrics["pr_auc"]["value"] == pytest.approx(0.833, abs=0.001)
 
 
 def test_classification_plots():
+    """
+    Verify that classification plotting functions (ROC, PR curves) return valid figure objects.
+    """
     y_true = [0, 1, 1, 0]
     y_pred = [[1, 0], [0, 1], [0, 1], [0, 1]]
 
     cp = ClassificationPlots()
     cp.evaluate(y_true, y_pred)
 
-    assert True
+    assert isinstance(cp.plot_data, dict)
+    assert "roc_curve" in cp.plot_data
+    assert "pr_curve" in cp.plot_data
+    assert isinstance(cp.plot_data["roc_curve"], matplotlib.figure.Figure)
+    assert isinstance(cp.plot_data["pr_curve"], matplotlib.figure.Figure)
 
 
 def test_posthoc_eval_metrics():
+    """
+    Test post-hoc binary metrics utility functions.
+
+    Verifies that we can calculate precision and recall at a specific cutoff threshold from
+    regression-like outputs (or probabilities).
+    """
     y_true = [3, -0.5, 2, 7]
     y_pred = [2.5, 0.0, 2, 8]
     cutoff = 4.0

--- a/openadmet/models/tests/unit/features/test_features.py
+++ b/openadmet/models/tests/unit/features/test_features.py
@@ -113,7 +113,7 @@ def test_feature_concatenator_drops_intersection(mocker):
     desc_features = np.zeros((3, 1613))
     desc_indices = np.array([0, 2, 3])
     mocker.patch.object(
-        DescriptorFeaturizer, "featurize", return_value=(desc_features, desc_indices)
+        DescriptorFeaturizer, "featurize", autospec=True, return_value=(desc_features, desc_indices)
     )
 
     # Mock fingerprint featurizer to return 3 valid outputs (fails on index 2)
@@ -122,7 +122,7 @@ def test_feature_concatenator_drops_intersection(mocker):
     fp_features = np.zeros((3, 2000))
     fp_indices = np.array([0, 1, 3])
     mocker.patch.object(
-        FingerprintFeaturizer, "featurize", return_value=(fp_features, fp_indices)
+        FingerprintFeaturizer, "featurize", autospec=True, return_value=(fp_features, fp_indices)
     )
 
     smiles = ["SMI0", "SMI1", "SMI2", "SMI3"]

--- a/openadmet/models/tests/unit/features/test_features.py
+++ b/openadmet/models/tests/unit/features/test_features.py
@@ -32,7 +32,9 @@ def one_invalid_smi():
     return ["CCO", "CCN", "invalid", "CCO"]
 
 
-@pytest.mark.parametrize("descr_type,dtype", [("mordred", np.float32), ("desc2d", np.float64)])
+@pytest.mark.parametrize(
+    "descr_type,dtype", [("mordred", np.float32), ("desc2d", np.float64)]
+)
 def test_descriptor_featurizer(descr_type, dtype):
     """
     Validate DescriptorFeaturizer for different descriptor types and floating point precisions.
@@ -100,7 +102,9 @@ def test_feature_concatenator(smiles, desc2d_featurizer, ecfp_featurizer):
     assert_array_equal(idx, np.arange(3))
 
 
-def test_feature_concatenator_drops_intersection(mocker, desc2d_featurizer, ecfp_featurizer):
+def test_feature_concatenator_drops_intersection(
+    mocker, desc2d_featurizer, ecfp_featurizer
+):
     """
     Verify that FeatureConcatenator only keeps molecules valid across ALL featurizers.
 
@@ -148,7 +152,9 @@ def test_feature_concatenator_drops_intersection(mocker, desc2d_featurizer, ecfp
     assert_array_equal(idx, np.array([0, 3]))
 
 
-def test_feature_concatenator_order_independence(smiles, desc2d_featurizer, ecfp_featurizer):
+def test_feature_concatenator_order_independence(
+    smiles, desc2d_featurizer, ecfp_featurizer
+):
     """
     Ensure that changing the order of featurizers in the list results in the same outcome due to sorting.
     """

--- a/openadmet/models/tests/unit/features/test_features.py
+++ b/openadmet/models/tests/unit/features/test_features.py
@@ -8,6 +8,18 @@ from openadmet.models.features.molfeat_properties import DescriptorFeaturizer
 from openadmet.models.features.pairwise import PairwiseFeaturizer
 
 
+@pytest.fixture(scope="session")
+def desc2d_featurizer():
+    """Provide a single shared DescriptorFeaturizer(desc2d) instance for the test session."""
+    return DescriptorFeaturizer(descr_type="desc2d", n_jobs=1)
+
+
+@pytest.fixture(scope="session")
+def ecfp_featurizer():
+    """Provide a single shared FingerprintFeaturizer(ecfp) instance for the test session."""
+    return FingerprintFeaturizer(fp_type="ecfp", n_jobs=1)
+
+
 @pytest.fixture()
 def smiles():
     """Provide a list of valid SMILES strings for testing featurization."""
@@ -20,8 +32,7 @@ def one_invalid_smi():
     return ["CCO", "CCN", "invalid", "CCO"]
 
 
-@pytest.mark.parametrize("dtype", (np.float32, np.float64))
-@pytest.mark.parametrize("descr_type", ["mordred", "desc2d"])
+@pytest.mark.parametrize("descr_type,dtype", [("mordred", np.float32), ("desc2d", np.float64)])
 def test_descriptor_featurizer(descr_type, dtype):
     """
     Validate DescriptorFeaturizer for different descriptor types and floating point precisions.
@@ -35,16 +46,15 @@ def test_descriptor_featurizer(descr_type, dtype):
     assert_array_equal(idx, np.arange(3))
 
 
-def test_descriptor_one_invalid(one_invalid_smi):
+def test_descriptor_one_invalid(one_invalid_smi, desc2d_featurizer):
     """
     Ensure DescriptorFeaturizer robustly handles invalid SMILES strings.
 
     The featurizer should skip invalid molecules and return indices corresponding only to the valid ones.
     This prevents the entire pipeline from crashing due to a single bad input.
     """
-    featurizer = DescriptorFeaturizer(descr_type="mordred")
-    X, idx = featurizer.featurize(one_invalid_smi)
-    assert X.shape == (3, 1613)
+    X, idx = desc2d_featurizer.featurize(one_invalid_smi)
+    assert X.shape == (3, 223)
     # index 2 is invalid, so the shape should be 3
     assert_array_equal(idx, np.asarray([0, 1, 3]))
 
@@ -65,35 +75,32 @@ def test_fingerprint_featurizer(smiles, fp_type, dtype):
     assert_array_equal(idx, np.arange(3))
 
 
-def test_fingerprint_one_invalid(one_invalid_smi):
+def test_fingerprint_one_invalid(one_invalid_smi, ecfp_featurizer):
     """
     Ensure FingerprintFeaturizer robustly handles invalid SMILES strings.
 
     Similar to descriptors, it should filter out invalid entries and return correct indices for valid ones.
     """
-    featurizer = FingerprintFeaturizer(fp_type="ecfp")
-    X, idx = featurizer.featurize(one_invalid_smi)
+    X, idx = ecfp_featurizer.featurize(one_invalid_smi)
     assert X.shape == (3, 2000)
     # index 2 is invalid, so the shape should be 3
     assert_array_equal(idx, np.asarray([0, 1, 3]))
 
 
-def test_feature_concatenator(smiles):
+def test_feature_concatenator(smiles, desc2d_featurizer, ecfp_featurizer):
     """
     Validate that FeatureConcatenator correctly combines multiple feature sets (descriptors + fingerprints).
 
     This ensures that different feature representations can be stacked horizontally for the same molecules,
     providing a richer feature set for training.
     """
-    desc_featurizer = DescriptorFeaturizer(descr_type="mordred")
-    fp_featurizer = FingerprintFeaturizer(fp_type="ecfp")
-    concat = FeatureConcatenator(featurizers=[desc_featurizer, fp_featurizer])
+    concat = FeatureConcatenator(featurizers=[desc2d_featurizer, ecfp_featurizer])
     X, idx = concat.featurize(smiles)
-    assert X.shape == (3, 3613)
+    assert X.shape == (3, 2223)
     assert_array_equal(idx, np.arange(3))
 
 
-def test_feature_concatenator_drops_intersection(mocker):
+def test_feature_concatenator_drops_intersection(mocker, desc2d_featurizer, ecfp_featurizer):
     """
     Verify that FeatureConcatenator only keeps molecules valid across ALL featurizers.
 
@@ -104,13 +111,11 @@ def test_feature_concatenator_drops_intersection(mocker):
     complex real-world molecules that fail specific featurizers. This isolates the intersection logic.
     """
     # Arrange
-    desc_featurizer = DescriptorFeaturizer(descr_type="mordred")
-    fp_featurizer = FingerprintFeaturizer(fp_type="ecfp")
-    concat = FeatureConcatenator(featurizers=[desc_featurizer, fp_featurizer])
+    concat = FeatureConcatenator(featurizers=[desc2d_featurizer, ecfp_featurizer])
 
     # Mock descriptor featurizer to return 3 valid outputs (fails on index 1)
     # Indices: 0, 2, 3 (skips 1)
-    desc_features = np.zeros((3, 1613))
+    desc_features = np.zeros((3, 223))
     desc_indices = np.array([0, 2, 3])
     mocker.patch.object(
         DescriptorFeaturizer,
@@ -138,22 +143,19 @@ def test_feature_concatenator_drops_intersection(mocker):
 
     # Assert
     # Intersection of [0, 2, 3] and [0, 1, 3] is [0, 3]
-    # Expected shape: (2, 1613 + 2000) = (2, 3613)
-    assert X.shape == (2, 3613)
+    # Expected shape: (2, 223 + 2000) = (2, 2223)
+    assert X.shape == (2, 2223)
     assert_array_equal(idx, np.array([0, 3]))
 
 
-def test_feature_concatenator_order_independence(smiles):
+def test_feature_concatenator_order_independence(smiles, desc2d_featurizer, ecfp_featurizer):
     """
     Ensure that changing the order of featurizers in the list results in the same outcome due to sorting.
     """
-    desc_featurizer = DescriptorFeaturizer(descr_type="mordred")
-    fp_featurizer = FingerprintFeaturizer(fp_type="ecfp")
-
-    concat1 = FeatureConcatenator(featurizers=[desc_featurizer, fp_featurizer])
+    concat1 = FeatureConcatenator(featurizers=[desc2d_featurizer, ecfp_featurizer])
     X1, idx1 = concat1.featurize(smiles)
 
-    concat2 = FeatureConcatenator(featurizers=[fp_featurizer, desc_featurizer])
+    concat2 = FeatureConcatenator(featurizers=[ecfp_featurizer, desc2d_featurizer])
     X2, idx2 = concat2.featurize(smiles)
 
     assert_array_equal(X1, X2)

--- a/openadmet/models/tests/unit/features/test_features.py
+++ b/openadmet/models/tests/unit/features/test_features.py
@@ -175,7 +175,7 @@ def test_pairwise_featurizer(smiles):
     (differences) are correctly computed.
     """
     featurizer = PairwiseFeaturizer(
-        featurizer={"FingerprintFeaturizer": {"fp_type": "ecfp", "dtype": np.float32}},
+        featurizer={"FingerprintFeaturizer": {"fp_type": "ecfp", "dtype": np.float32, "n_jobs": 1}},
         how_to_pair="full",
         batch_size=2,
         shuffle=False,

--- a/openadmet/models/tests/unit/features/test_features.py
+++ b/openadmet/models/tests/unit/features/test_features.py
@@ -42,7 +42,7 @@ def test_descriptor_featurizer(descr_type, dtype):
     This ensures that physical-chemical descriptors (like Mordred or RDKit 2D) are correctly generated
     and returned with the requested data type, which is important for downstream model compatibility.
     """
-    featurizer = DescriptorFeaturizer(descr_type=descr_type, dtype=dtype)
+    featurizer = DescriptorFeaturizer(descr_type=descr_type, dtype=dtype, n_jobs=1)
     X, idx = featurizer.featurize(["CCO", "CCN", "CCO"])
     assert X.dtype == dtype
     assert_array_equal(idx, np.arange(3))
@@ -61,8 +61,7 @@ def test_descriptor_one_invalid(one_invalid_smi, desc2d_featurizer):
     assert_array_equal(idx, np.asarray([0, 1, 3]))
 
 
-@pytest.mark.parametrize("dtype", (np.float32, np.float64))
-@pytest.mark.parametrize("fp_type", ("ecfp", "fcfp"))
+@pytest.mark.parametrize("fp_type,dtype", [("ecfp", np.float32), ("fcfp", np.float64)])
 def test_fingerprint_featurizer(smiles, fp_type, dtype):
     """
     Validate FingerprintFeaturizer for different fingerprint types (ECFP, FCFP) and precisions.
@@ -70,7 +69,7 @@ def test_fingerprint_featurizer(smiles, fp_type, dtype):
     This verifies that structural fingerprints are correctly generated with the expected vector size (2000)
     and data type.
     """
-    featurizer = FingerprintFeaturizer(fp_type=fp_type, dtype=dtype)
+    featurizer = FingerprintFeaturizer(fp_type=fp_type, dtype=dtype, n_jobs=1)
     X, idx = featurizer.featurize(smiles)
     assert X.shape == (3, 2000)
     assert X.dtype == dtype

--- a/openadmet/models/tests/unit/features/test_features.py
+++ b/openadmet/models/tests/unit/features/test_features.py
@@ -113,7 +113,10 @@ def test_feature_concatenator_drops_intersection(mocker):
     desc_features = np.zeros((3, 1613))
     desc_indices = np.array([0, 2, 3])
     mocker.patch.object(
-        DescriptorFeaturizer, "featurize", autospec=True, return_value=(desc_features, desc_indices)
+        DescriptorFeaturizer,
+        "featurize",
+        autospec=True,
+        return_value=(desc_features, desc_indices),
     )
 
     # Mock fingerprint featurizer to return 3 valid outputs (fails on index 2)
@@ -122,7 +125,10 @@ def test_feature_concatenator_drops_intersection(mocker):
     fp_features = np.zeros((3, 2000))
     fp_indices = np.array([0, 1, 3])
     mocker.patch.object(
-        FingerprintFeaturizer, "featurize", autospec=True, return_value=(fp_features, fp_indices)
+        FingerprintFeaturizer,
+        "featurize",
+        autospec=True,
+        return_value=(fp_features, fp_indices),
     )
 
     smiles = ["SMI0", "SMI1", "SMI2", "SMI3"]

--- a/openadmet/models/tests/unit/features/test_features.py
+++ b/openadmet/models/tests/unit/features/test_features.py
@@ -10,17 +10,25 @@ from openadmet.models.features.pairwise import PairwiseFeaturizer
 
 @pytest.fixture()
 def smiles():
+    """Provide a list of valid SMILES strings for testing featurization."""
     return ["CCO", "CCN", "CCO"]
 
 
 @pytest.fixture()
 def one_invalid_smi():
+    """Provide a list of SMILES strings containing one invalid entry to test error handling."""
     return ["CCO", "CCN", "invalid", "CCO"]
 
 
 @pytest.mark.parametrize("dtype", (np.float32, np.float64))
 @pytest.mark.parametrize("descr_type", ["mordred", "desc2d"])
 def test_descriptor_featurizer(descr_type, dtype):
+    """
+    Validate DescriptorFeaturizer for different descriptor types and floating point precisions.
+
+    This ensures that physical-chemical descriptors (like Mordred or RDKit 2D) are correctly generated
+    and returned with the requested data type, which is important for downstream model compatibility.
+    """
     featurizer = DescriptorFeaturizer(descr_type=descr_type, dtype=dtype)
     X, idx = featurizer.featurize(["CCO", "CCN", "CCO"])
     assert X.dtype == dtype
@@ -28,6 +36,12 @@ def test_descriptor_featurizer(descr_type, dtype):
 
 
 def test_descriptor_one_invalid(one_invalid_smi):
+    """
+    Ensure DescriptorFeaturizer robustly handles invalid SMILES strings.
+
+    The featurizer should skip invalid molecules and return indices corresponding only to the valid ones.
+    This prevents the entire pipeline from crashing due to a single bad input.
+    """
     featurizer = DescriptorFeaturizer(descr_type="mordred")
     X, idx = featurizer.featurize(one_invalid_smi)
     assert X.shape == (3, 1613)
@@ -38,6 +52,12 @@ def test_descriptor_one_invalid(one_invalid_smi):
 @pytest.mark.parametrize("dtype", (np.float32, np.float64))
 @pytest.mark.parametrize("fp_type", ("ecfp", "fcfp"))
 def test_fingerprint_featurizer(smiles, fp_type, dtype):
+    """
+    Validate FingerprintFeaturizer for different fingerprint types (ECFP, FCFP) and precisions.
+
+    This verifies that structural fingerprints are correctly generated with the expected vector size (2000)
+    and data type.
+    """
     featurizer = FingerprintFeaturizer(fp_type=fp_type, dtype=dtype)
     X, idx = featurizer.featurize(smiles)
     assert X.shape == (3, 2000)
@@ -46,6 +66,11 @@ def test_fingerprint_featurizer(smiles, fp_type, dtype):
 
 
 def test_fingerprint_one_invalid(one_invalid_smi):
+    """
+    Ensure FingerprintFeaturizer robustly handles invalid SMILES strings.
+
+    Similar to descriptors, it should filter out invalid entries and return correct indices for valid ones.
+    """
     featurizer = FingerprintFeaturizer(fp_type="ecfp")
     X, idx = featurizer.featurize(one_invalid_smi)
     assert X.shape == (3, 2000)
@@ -54,6 +79,12 @@ def test_fingerprint_one_invalid(one_invalid_smi):
 
 
 def test_feature_concatenator(smiles):
+    """
+    Validate that FeatureConcatenator correctly combines multiple feature sets (descriptors + fingerprints).
+
+    This ensures that different feature representations can be stacked horizontally for the same molecules,
+    providing a richer feature set for training.
+    """
     desc_featurizer = DescriptorFeaturizer(descr_type="mordred")
     fp_featurizer = FingerprintFeaturizer(fp_type="ecfp")
     concat = FeatureConcatenator(featurizers=[desc_featurizer, fp_featurizer])
@@ -62,14 +93,48 @@ def test_feature_concatenator(smiles):
     assert_array_equal(idx, np.arange(3))
 
 
-def test_feature_concatenator_failed_diff_positions(one_invalid_smi):
+def test_feature_concatenator_drops_intersection(mocker):
+    """
+    Verify that FeatureConcatenator only keeps molecules valid across ALL featurizers.
+
+    If one featurizer fails for molecule A and another fails for molecule B, the concatenator
+    must drop both A and B to maintain feature alignment.
+
+    We mock the underlying featurizers to control which indices fail, avoiding the need for
+    complex real-world molecules that fail specific featurizers. This isolates the intersection logic.
+    """
+    # Arrange
     desc_featurizer = DescriptorFeaturizer(descr_type="mordred")
     fp_featurizer = FingerprintFeaturizer(fp_type="ecfp")
     concat = FeatureConcatenator(featurizers=[desc_featurizer, fp_featurizer])
-    X, idx = concat.featurize(one_invalid_smi)
-    assert X.shape == (3, 3613)
-    # index 2 is invalid, so the shape should be 3
-    assert_array_equal(idx, np.asarray([0, 1, 3]))
+
+    # Mock descriptor featurizer to return 3 valid outputs (fails on index 1)
+    # Indices: 0, 2, 3 (skips 1)
+    desc_features = np.zeros((3, 1613))
+    desc_indices = np.array([0, 2, 3])
+    mocker.patch.object(
+        DescriptorFeaturizer, "featurize", return_value=(desc_features, desc_indices)
+    )
+
+    # Mock fingerprint featurizer to return 3 valid outputs (fails on index 2)
+    # Indices: 0, 1, 3 (skips 2)
+    # Note: ECFP size is 2000 in this codebase
+    fp_features = np.zeros((3, 2000))
+    fp_indices = np.array([0, 1, 3])
+    mocker.patch.object(
+        FingerprintFeaturizer, "featurize", return_value=(fp_features, fp_indices)
+    )
+
+    smiles = ["SMI0", "SMI1", "SMI2", "SMI3"]
+
+    # Act
+    X, idx = concat.featurize(smiles)
+
+    # Assert
+    # Intersection of [0, 2, 3] and [0, 1, 3] is [0, 3]
+    # Expected shape: (2, 1613 + 2000) = (2, 3613)
+    assert X.shape == (2, 3613)
+    assert_array_equal(idx, np.array([0, 3]))
 
 
 def test_feature_concatenator_order_independence(smiles):
@@ -90,6 +155,12 @@ def test_feature_concatenator_order_independence(smiles):
 
 
 def test_pairwise_featurizer(smiles):
+    """
+    Validate PairwiseFeaturizer in 'full' mode (all-pairs).
+
+    This tests that features are generated for every pair of molecules and that target values
+    (differences) are correctly computed.
+    """
     featurizer = PairwiseFeaturizer(
         featurizer={"FingerprintFeaturizer": {"fp_type": "ecfp", "dtype": np.float32}},
         how_to_pair="full",

--- a/openadmet/models/tests/unit/features/test_features.py
+++ b/openadmet/models/tests/unit/features/test_features.py
@@ -175,7 +175,13 @@ def test_pairwise_featurizer(smiles):
     (differences) are correctly computed.
     """
     featurizer = PairwiseFeaturizer(
-        featurizer={"FingerprintFeaturizer": {"fp_type": "ecfp", "dtype": np.float32, "n_jobs": 1}},
+        featurizer={
+            "FingerprintFeaturizer": {
+                "fp_type": "ecfp",
+                "dtype": np.float32,
+                "n_jobs": 1,
+            }
+        },
         how_to_pair="full",
         batch_size=2,
         shuffle=False,

--- a/openadmet/models/tests/unit/features/test_nepare.py
+++ b/openadmet/models/tests/unit/features/test_nepare.py
@@ -9,6 +9,12 @@ from openadmet.models.features.pairwise import PairwiseFeaturizer
 
 
 def test_pairwise_make_new():
+    """
+    Verify that PairwiseFeaturizer can create a new independent instance via make_new().
+
+    This is important for factory-like creation patterns in the registry or during cross-validation
+    where fresh featurizers are needed.
+    """
     featurizer = PairwiseFeaturizer(
         how_to_pair="full", featurizer=FingerprintFeaturizer(fp_type="ecfp:4")
     )

--- a/openadmet/models/tests/unit/inference/test_inference.py
+++ b/openadmet/models/tests/unit/inference/test_inference.py
@@ -1,15 +1,9 @@
 """Tests for the inference orchestration pipeline using real, lightweight components."""
 
-from pathlib import Path
-
 import numpy as np
 import pandas as pd
 import pytest
 
-from openadmet.models.active_learning.committee import CommitteeRegressor
-from openadmet.models.anvil.specification import DataSpec, Metadata
-from openadmet.models.architecture.dummy import DummyRegressorModel
-from openadmet.models.features.molfeat_fingerprint import FingerprintFeaturizer
 from openadmet.models.inference import inference as inference_module
 
 
@@ -19,111 +13,18 @@ def input_df():
     return pd.DataFrame({"MY_SMILES": ["CCO", "CCN"]})
 
 
-@pytest.fixture(scope="module")
-def real_featurizer():
-    """Return a real FingerprintFeaturizer using ECFP4 fingerprints."""
-    return FingerprintFeaturizer(fp_type="ecfp:4")
+def test_predict_with_real_single_model(input_df, null_single_model_dir):
+    """Test the inference pipeline end-to-end with a real on-disk DummyRegressorModel.
 
-
-@pytest.fixture(scope="module")
-def real_data_spec():
-    """Return a real DataSpec with a single regression target."""
-    return DataSpec(type="csv", target_cols=["task_0"], input_col="MY_SMILES")
-
-
-@pytest.fixture(scope="module")
-def real_metadata_single():
-    """Return real Metadata with tag UNIT for single-model tests."""
-    return Metadata(
-        version="v1",
-        driver="sklearn",
-        name="unit-test",
-        build_number=0,
-        description="Unit test model",
-        tag="UNIT",
-        authors="Test Author",
-        email="test@example.com",
-        biotargets=["test"],
-        tags=["test"],
-    )
-
-
-@pytest.fixture(scope="module")
-def real_metadata_ensemble():
-    """Return real Metadata with tag ENS for ensemble tests."""
-    return Metadata(
-        version="v1",
-        driver="sklearn",
-        name="ens-test",
-        build_number=0,
-        description="Ensemble test model",
-        tag="ENS",
-        authors="Test Author",
-        email="test@example.com",
-        biotargets=["test"],
-        tags=["test"],
-    )
-
-
-@pytest.fixture(scope="module")
-def trained_single_model():
-    """Return a DummyRegressorModel trained to always predict 1.0 regardless of input features."""
-    X_train = np.zeros((3, 2))
-    y_train = np.array([[1.0], [1.0], [1.0]])
-    model = DummyRegressorModel()
-    model.train(X_train, y_train)
-    return model
-
-
-@pytest.fixture(scope="module")
-def trained_ensemble():
-    """Return a CommitteeRegressor whose two members predict 1.0 and 3.0 respectively.
-
-    The ensemble mean is 2.0 and the standard deviation is 1.0 for any input,
-    making the UCB score with beta=2.0 equal to 4.0.
+    SMILES strings are featurized by NullFeaturizer and passed to a DummyRegressorModel
+    loaded from disk via load_anvil_model_and_metadata. Because DummyRegressorModel always
+    predicts the training mean (1.0), PRED values must equal 1.0 for both inputs.
+    The STD column must be NaN because non-ensemble models produce no uncertainty estimate.
     """
-    X_train = np.zeros((3, 2))
-
-    model1 = DummyRegressorModel()
-    model1.train(X_train, np.array([[1.0], [1.0], [1.0]]))
-
-    model2 = DummyRegressorModel()
-    model2.train(X_train, np.array([[3.0], [3.0], [3.0]]))
-
-    return CommitteeRegressor.from_models([model1, model2])
-
-
-def test_predict_with_real_single_model(
-    mocker,
-    input_df,
-    real_featurizer,
-    real_metadata_single,
-    real_data_spec,
-    trained_single_model,
-):
-    """Test the inference pipeline with a real DummyRegressorModel.
-
-    SMILES strings flow through a real FingerprintFeaturizer and a real DummyRegressorModel
-    to verify internal data plumbing. Because DummyRegressorModel always predicts the
-    training mean, PRED values must equal 1.0 for both inputs. The STD column must be NaN
-    because non-ensemble models produce no uncertainty estimate.
-    """
-    mock_loader = mocker.patch.object(
-        inference_module,
-        "load_anvil_model_and_metadata",
-        autospec=True,
-        return_value=(
-            trained_single_model,
-            real_featurizer,
-            real_metadata_single,
-            real_data_spec,
-        ),
-    )
-
     result = inference_module.predict(
         input_path=input_df,
         input_col="MY_SMILES",
-        model_dir=["unused-model-dir"],
+        model_dir=[null_single_model_dir],
         accelerator="cpu",
         log=False,
     )
@@ -131,50 +32,29 @@ def test_predict_with_real_single_model(
     assert isinstance(result, pd.DataFrame)
     assert "OADMET_PRED_UNIT_task_0" in result.columns
     assert "OADMET_STD_UNIT_task_0" in result.columns
-    assert result["OADMET_PRED_UNIT_task_0"].tolist() == pytest.approx([1.0, 1.0])
+    assert np.allclose(result["OADMET_PRED_UNIT_task_0"].to_numpy(), [1.0, 1.0])
     assert result["OADMET_STD_UNIT_task_0"].isna().all()
-    mock_loader.assert_called_once_with(Path("unused-model-dir"))
 
 
-def test_predict_with_real_ensemble_and_acquisition(
-    mocker,
-    input_df,
-    real_featurizer,
-    real_metadata_ensemble,
-    real_data_spec,
-    trained_ensemble,
-):
-    """Test the inference pipeline with a real CommitteeRegressor and UCB acquisition.
+def test_predict_with_real_ensemble_and_acquisition(input_df, null_ensemble_model_dir):
+    """Test the inference pipeline end-to-end with a real on-disk CommitteeRegressor.
 
-    Two DummyRegressorModel members predict 1.0 and 3.0 respectively, yielding a committee
-    mean of 2.0 and standard deviation of 1.0 for any input. With beta=2.0,
-    UCB = mean + beta * std = 2.0 + 2.0 * 1.0 = 4.0.
+    Two DummyRegressorModel members (predicting 1.0 and 3.0) are loaded from disk and
+    assembled into a CommitteeRegressor. The ensemble mean is 2.0 and the standard
+    deviation is 1.0 for any input. With beta=2.0, UCB = mean + beta * std = 4.0.
     """
-    mock_loader = mocker.patch.object(
-        inference_module,
-        "load_anvil_model_and_metadata",
-        autospec=True,
-        return_value=(
-            trained_ensemble,
-            real_featurizer,
-            real_metadata_ensemble,
-            real_data_spec,
-        ),
-    )
-
     result = inference_module.predict(
         input_path=input_df,
         input_col="MY_SMILES",
-        model_dir=["unused-model-dir"],
+        model_dir=[null_ensemble_model_dir],
         accelerator="cpu",
         log=False,
         aq_fxn_args={"ucb": {"beta": 2.0}},
     )
 
-    assert result["OADMET_PRED_ENS_task_0"].tolist() == pytest.approx([2.0, 2.0])
-    assert result["OADMET_STD_ENS_task_0"].tolist() == pytest.approx([1.0, 1.0])
-    assert result["OADMET_UCB_ENS_task_0"].tolist() == pytest.approx([4.0, 4.0])
-    mock_loader.assert_called_once_with(Path("unused-model-dir"))
+    assert np.allclose(result["OADMET_PRED_ENS_task_0"].to_numpy(), [2.0, 2.0])
+    assert np.allclose(result["OADMET_STD_ENS_task_0"].to_numpy(), [1.0, 1.0])
+    assert np.allclose(result["OADMET_UCB_ENS_task_0"].to_numpy(), [4.0, 4.0])
 
 
 def test_predict_raises_when_input_column_missing(input_df):

--- a/openadmet/models/tests/unit/inference/test_inference.py
+++ b/openadmet/models/tests/unit/inference/test_inference.py
@@ -111,6 +111,7 @@ def test_predict_with_real_single_model(
     mock_loader = mocker.patch.object(
         inference_module,
         "load_anvil_model_and_metadata",
+        autospec=True,
         return_value=(
             trained_single_model,
             real_featurizer,
@@ -152,6 +153,7 @@ def test_predict_with_real_ensemble_and_acquisition(
     mock_loader = mocker.patch.object(
         inference_module,
         "load_anvil_model_and_metadata",
+        autospec=True,
         return_value=(
             trained_ensemble,
             real_featurizer,

--- a/openadmet/models/tests/unit/inference/test_inference.py
+++ b/openadmet/models/tests/unit/inference/test_inference.py
@@ -1,50 +1,204 @@
+"""Tests for the inference orchestration pipeline using real, lightweight components."""
+
 from pathlib import Path
+
+import numpy as np
 import pandas as pd
-import os
 import pytest
 
-from openadmet.models.inference.inference import predict
-from openadmet.models.tests.unit.datafiles import (
-    pred_test_data_csv,
-    anvil_lgbm_trained_model_dir,
-    anvil_chemprop_trained_model_dir,
-)
+from openadmet.models.active_learning.committee import CommitteeRegressor
+from openadmet.models.anvil.specification import DataSpec, Metadata
+from openadmet.models.architecture.dummy import DummyRegressorModel
+from openadmet.models.features.molfeat_fingerprint import FingerprintFeaturizer
+from openadmet.models.inference import inference as inference_module
 
 
 @pytest.fixture
-def anvil_lgbm():
-    return anvil_lgbm_trained_model_dir
+def input_df():
+    """Provide a simple DataFrame with SMILES for testing inference inputs."""
+    return pd.DataFrame({"MY_SMILES": ["CCO", "CCN"]})
 
 
-@pytest.fixture
-def anvil_chemprop():
-    return anvil_chemprop_trained_model_dir
+@pytest.fixture(scope="module")
+def real_featurizer():
+    """Return a real FingerprintFeaturizer using ECFP4 fingerprints."""
+    return FingerprintFeaturizer(fp_type="ecfp:4")
 
 
-@pytest.mark.skipif(
-    os.getenv("RUNNER_OS") == "macOS", reason="MacOS runner not enough memory"
-)
-@pytest.mark.parametrize("model_dir", ["anvil_lgbm", "anvil_chemprop"])
-def test_predict(model_dir, request):
-    # Use the fixture to get the model directory
-    model_dir = request.getfixturevalue(model_dir)
-    # Test the predict function with a sample input
-    input_path = pred_test_data_csv
-    input_col = "MY_SMILES"
-    model_dir = [model_dir]
-    write_csv = False
-    output_path = None
-    debug = False
+@pytest.fixture(scope="module")
+def real_data_spec():
+    """Return a real DataSpec with a single regression target."""
+    return DataSpec(type="csv", target_cols=["task_0"], input_col="MY_SMILES")
 
-    result = predict(
-        input_path,
-        input_col,
-        model_dir,
-        write_csv,
-        output_path,
-        debug=False,
-        accelerator="cpu",
+
+@pytest.fixture(scope="module")
+def real_metadata_single():
+    """Return real Metadata with tag UNIT for single-model tests."""
+    return Metadata(
+        version="v1",
+        driver="sklearn",
+        name="unit-test",
+        build_number=0,
+        description="Unit test model",
+        tag="UNIT",
+        authors="Test Author",
+        email="test@example.com",
+        biotargets=["test"],
+        tags=["test"],
     )
 
-    # Check if the result is a DataFrame
+
+@pytest.fixture(scope="module")
+def real_metadata_ensemble():
+    """Return real Metadata with tag ENS for ensemble tests."""
+    return Metadata(
+        version="v1",
+        driver="sklearn",
+        name="ens-test",
+        build_number=0,
+        description="Ensemble test model",
+        tag="ENS",
+        authors="Test Author",
+        email="test@example.com",
+        biotargets=["test"],
+        tags=["test"],
+    )
+
+
+@pytest.fixture(scope="module")
+def trained_single_model():
+    """Return a DummyRegressorModel trained to always predict 1.0 regardless of input features."""
+    X_train = np.zeros((3, 2))
+    y_train = np.array([[1.0], [1.0], [1.0]])
+    model = DummyRegressorModel()
+    model.train(X_train, y_train)
+    return model
+
+
+@pytest.fixture(scope="module")
+def trained_ensemble():
+    """Return a CommitteeRegressor whose two members predict 1.0 and 3.0 respectively.
+
+    The ensemble mean is 2.0 and the standard deviation is 1.0 for any input,
+    making the UCB score with beta=2.0 equal to 4.0.
+    """
+    X_train = np.zeros((3, 2))
+
+    model1 = DummyRegressorModel()
+    model1.train(X_train, np.array([[1.0], [1.0], [1.0]]))
+
+    model2 = DummyRegressorModel()
+    model2.train(X_train, np.array([[3.0], [3.0], [3.0]]))
+
+    return CommitteeRegressor.from_models([model1, model2])
+
+
+def test_predict_with_real_single_model(
+    mocker,
+    input_df,
+    real_featurizer,
+    real_metadata_single,
+    real_data_spec,
+    trained_single_model,
+):
+    """Test the inference pipeline with a real DummyRegressorModel.
+
+    SMILES strings flow through a real FingerprintFeaturizer and a real DummyRegressorModel
+    to verify internal data plumbing. Because DummyRegressorModel always predicts the
+    training mean, PRED values must equal 1.0 for both inputs. The STD column must be NaN
+    because non-ensemble models produce no uncertainty estimate.
+    """
+    mock_loader = mocker.patch.object(
+        inference_module,
+        "load_anvil_model_and_metadata",
+        return_value=(
+            trained_single_model,
+            real_featurizer,
+            real_metadata_single,
+            real_data_spec,
+        ),
+    )
+
+    result = inference_module.predict(
+        input_path=input_df,
+        input_col="MY_SMILES",
+        model_dir=["unused-model-dir"],
+        accelerator="cpu",
+        log=False,
+    )
+
     assert isinstance(result, pd.DataFrame)
+    assert "OADMET_PRED_UNIT_task_0" in result.columns
+    assert "OADMET_STD_UNIT_task_0" in result.columns
+    assert result["OADMET_PRED_UNIT_task_0"].tolist() == pytest.approx([1.0, 1.0])
+    assert result["OADMET_STD_UNIT_task_0"].isna().all()
+    mock_loader.assert_called_once_with(Path("unused-model-dir"))
+
+
+def test_predict_with_real_ensemble_and_acquisition(
+    mocker,
+    input_df,
+    real_featurizer,
+    real_metadata_ensemble,
+    real_data_spec,
+    trained_ensemble,
+):
+    """Test the inference pipeline with a real CommitteeRegressor and UCB acquisition.
+
+    Two DummyRegressorModel members predict 1.0 and 3.0 respectively, yielding a committee
+    mean of 2.0 and standard deviation of 1.0 for any input. With beta=2.0,
+    UCB = mean + beta * std = 2.0 + 2.0 * 1.0 = 4.0.
+    """
+    mock_loader = mocker.patch.object(
+        inference_module,
+        "load_anvil_model_and_metadata",
+        return_value=(
+            trained_ensemble,
+            real_featurizer,
+            real_metadata_ensemble,
+            real_data_spec,
+        ),
+    )
+
+    result = inference_module.predict(
+        input_path=input_df,
+        input_col="MY_SMILES",
+        model_dir=["unused-model-dir"],
+        accelerator="cpu",
+        log=False,
+        aq_fxn_args={"ucb": {"beta": 2.0}},
+    )
+
+    assert result["OADMET_PRED_ENS_task_0"].tolist() == pytest.approx([2.0, 2.0])
+    assert result["OADMET_STD_ENS_task_0"].tolist() == pytest.approx([1.0, 1.0])
+    assert result["OADMET_UCB_ENS_task_0"].tolist() == pytest.approx([4.0, 4.0])
+    mock_loader.assert_called_once_with(Path("unused-model-dir"))
+
+
+def test_predict_raises_when_input_column_missing(input_df):
+    """Ensure that the inference function validates the existence of the specified SMILES column."""
+    with pytest.raises(ValueError, match="Column OTHER not found"):
+        inference_module.predict(
+            input_path=input_df,
+            input_col="OTHER",
+            model_dir=["unused-model-dir"],
+            log=False,
+        )
+
+
+def test_load_anvil_model_and_metadata_missing_recipe_components(tmp_path):
+    """Ensure correct error is raised when the model directory structure is invalid."""
+    with pytest.raises(FileNotFoundError, match="does not contain recipe components"):
+        inference_module.load_anvil_model_and_metadata(tmp_path)
+
+
+def test_load_anvil_model_and_metadata_missing_procedure_yaml(tmp_path):
+    """Ensure correct error is raised when critical YAML metadata files are missing."""
+    model_dir = tmp_path / "model"
+    recipe_components = model_dir / "recipe_components"
+    recipe_components.mkdir(parents=True)
+    (recipe_components / "metadata.yaml").write_text("metadata")
+    (recipe_components / "data.yaml").write_text("data")
+
+    with pytest.raises(FileNotFoundError, match="does not contain procedure.yaml"):
+        inference_module.load_anvil_model_and_metadata(model_dir)

--- a/openadmet/models/tests/unit/models/test_base.py
+++ b/openadmet/models/tests/unit/models/test_base.py
@@ -1,5 +1,4 @@
 from types import SimpleNamespace
-from unittest.mock import Mock
 
 import pytest
 
@@ -48,12 +47,18 @@ def test_save_load_torch_model(mclass, tmp_path):
     loaded_model.load(tmp_path / "test_model.pth")
 
 
-def test_lightning_model_load_uses_weights_only(monkeypatch, tmp_path):
-    state_dict = {"layer.weight": "dummy"}
-    torch_load = Mock(return_value=state_dict)
-    monkeypatch.setattr(model_base.torch, "load", torch_load)
+def test_lightning_model_load_uses_weights_only(mocker, tmp_path):
+    """
+    Verify that LightningModelBase.load calls torch.load with weights_only=True.
 
-    estimator = Mock()
+    We mock torch.load to avoid requiring a real .pth file and to capture the call arguments.
+    We mock estimator.load_state_dict because both calls are in a single expression in the
+    implementation, making it impossible to test one without the other.
+    """
+    state_dict = {"layer.weight": "dummy"}
+    torch_load = mocker.patch.object(model_base.torch, "load", return_value=state_dict)
+
+    estimator = mocker.Mock()
     model = SimpleNamespace(estimator=estimator)
     path = tmp_path / "test_model.pth"
 

--- a/openadmet/models/tests/unit/models/test_base.py
+++ b/openadmet/models/tests/unit/models/test_base.py
@@ -42,4 +42,3 @@ def test_save_load_torch_model(mclass, tmp_path):
     loaded_model = mclass()
     loaded_model.build()
     loaded_model.load(tmp_path / "test_model.pth")
-

--- a/openadmet/models/tests/unit/models/test_base.py
+++ b/openadmet/models/tests/unit/models/test_base.py
@@ -1,8 +1,5 @@
-from types import SimpleNamespace
-
 import pytest
 
-import openadmet.models.architecture.model_base as model_base
 from openadmet.models.architecture.model_base import (
     LightningModelBase,
     PickleableModelBase,
@@ -46,23 +43,3 @@ def test_save_load_torch_model(mclass, tmp_path):
     loaded_model.build()
     loaded_model.load(tmp_path / "test_model.pth")
 
-
-def test_lightning_model_load_uses_weights_only(mocker, tmp_path):
-    """
-    Verify that LightningModelBase.load calls torch.load with weights_only=True.
-
-    We mock torch.load to avoid requiring a real .pth file and to capture the call arguments.
-    We mock estimator.load_state_dict because both calls are in a single expression in the
-    implementation, making it impossible to test one without the other.
-    """
-    state_dict = {"layer.weight": "dummy"}
-    torch_load = mocker.patch.object(model_base.torch, "load", return_value=state_dict)
-
-    estimator = mocker.Mock()
-    model = SimpleNamespace(estimator=estimator)
-    path = tmp_path / "test_model.pth"
-
-    LightningModelBase.load(model, path)
-
-    torch_load.assert_called_once_with(path, weights_only=True)
-    estimator.load_state_dict.assert_called_once_with(state_dict)

--- a/openadmet/models/tests/unit/models/test_base.py
+++ b/openadmet/models/tests/unit/models/test_base.py
@@ -13,6 +13,13 @@ from openadmet.models.architecture.model_base import (
 
 @pytest.mark.parametrize("mclass", models.classes())
 def test_save_load_pickleable(mclass, tmp_path):
+    """
+    Verify save/load mechanics for all registered pickleable models (e.g., sklearn-based).
+
+    This iterates through the model registry and tests that any model inheriting from PickleableModelBase
+    can be instantiated, built, saved, and loaded without error. This is a crucial contract test
+    ensuring all registered models comply with the persistence interface.
+    """
     if not issubclass(mclass, PickleableModelBase):
         pytest.skip(f"Skipping non-pickleable model {mclass.__name__}")
     model = mclass()
@@ -25,6 +32,12 @@ def test_save_load_pickleable(mclass, tmp_path):
 
 @pytest.mark.parametrize("mclass", models.classes())
 def test_save_load_torch_model(mclass, tmp_path):
+    """
+    Verify save/load mechanics for all registered PyTorch Lightning models.
+
+    Similar to the pickleable test, this ensures that deep learning models (inheriting from LightningModelBase)
+    implement the correct save/load logic for their weights and configurations.
+    """
     if not issubclass(mclass, LightningModelBase):
         pytest.skip(f"Skipping non-torch model {mclass.__name__}")
     model = mclass()

--- a/openadmet/models/tests/unit/models/test_lgbm.py
+++ b/openadmet/models/tests/unit/models/test_lgbm.py
@@ -6,17 +6,24 @@ from openadmet.models.architecture.lgbm import LGBMRegressorModel
 
 @pytest.fixture
 def X_y():
+    """Provide simple synthetic data for basic model training tests."""
     X = [[1, 2, 3], [4, 5, 6]]
     y = [1, 2]
     return X, y
 
 
 def test_lgbm():
+    """Verify that LGBMRegressorModel initializes with the correct type identifier."""
     lgbm_model = LGBMRegressorModel()
     assert lgbm_model.type == "LGBMRegressorModel"
 
 
 def test_lgbm_from_params():
+    """
+    Validate that hyperparameters passed to the constructor are correctly applied to the underlying estimator.
+
+    This ensures that user configurations (like n_estimators) are respected by the model.
+    """
     lgbm_model = LGBMRegressorModel(n_estimators=100, boosting_type="rf")
     lgbm_model.build()
     assert lgbm_model.type == "LGBMRegressorModel"
@@ -25,6 +32,11 @@ def test_lgbm_from_params():
 
 
 def test_lgbm_train_predict(X_y):
+    """
+    Verify the train and predict lifecycle of LGBMRegressorModel.
+
+    This checks that the model can fit to data and generate predictions with the expected shape and values.
+    """
     lgbm_model = LGBMRegressorModel(n_estimators=100)
     lgbm_model.build()
     X, y = X_y
@@ -41,6 +53,11 @@ def test_lgbm_train_predict(X_y):
 
 
 def test_lgbm_save_load(tmp_path, X_y):
+    """
+    Validate persistence of the LGBM model to disk.
+
+    Ensures that saving and reloading the model preserves its learned state and prediction behavior.
+    """
     lgbm_model = LGBMRegressorModel(n_estimators=100)
     lgbm_model.build()
     X, y = X_y
@@ -54,6 +71,12 @@ def test_lgbm_save_load(tmp_path, X_y):
 
 
 def test_serialization(tmp_path, X_y):
+    """
+    Validate JSON/pickle serialization workflow for LGBM models.
+
+    This tests the separate storage of hyperparameters (JSON) and model weights (pickle),
+    which is used for model registry and versioning.
+    """
     lgbm_model = LGBMRegressorModel(n_estimators=100)
     lgbm_model.build()
     X, y = X_y

--- a/openadmet/models/tests/unit/models/test_nepare.py
+++ b/openadmet/models/tests/unit/models/test_nepare.py
@@ -6,11 +6,13 @@ from openadmet.models.architecture.nepare import NeuralPairwiseRegressorModel
 
 @pytest.fixture
 def X_y():
+    """Provide synthetic data pairs for testing pairwise regression."""
     X = [[1, 2, 3], [4, 5, 6]]
     y = [1, 2]
     return X, y
 
 
 def test_nepare():
+    """Verify initialization of the NeuralPairwiseRegressorModel."""
     nepare_model = NeuralPairwiseRegressorModel()
     assert nepare_model.type == "NeuralPairwiseRegressorModel"

--- a/openadmet/models/tests/unit/split/test_splitters.py
+++ b/openadmet/models/tests/unit/split/test_splitters.py
@@ -5,10 +5,10 @@ import pandas as pd
 from openadmet.models.split.sklearn import ShuffleSplitter
 from openadmet.models.split.cluster import ClusterSplitter
 from openadmet.models.split.split_base import splitters
-from openadmet.models.tests.unit.datafiles import CYP3A4_chembl_pchembl
 
 
 def test_in_splitters():
+    """Verify that concrete splitter implementations are correctly registered in the splitters registry."""
     assert "ShuffleSplitter" in splitters
     assert "ClusterSplitter" in splitters
 
@@ -34,10 +34,15 @@ def test_in_splitters():
 def test_simple_split(
     train_size, val_size, test_size, expected_train, expected_val, expected_test, error
 ):
-    # Error expected
+    """
+    Validate that ShuffleSplitter correctly partitions data according to specified ratios.
+
+    This test verifies both successful splits and error handling for invalid configurations.
+    Correct splitting ensures that training, validation, and test sets are of the expected size
+    and are mutually exclusive, which is critical for valid model evaluation.
+    """
     if error is True:
         with pytest.raises(ValueError):
-            # Initialize splitter
             splitter = ShuffleSplitter(
                 train_size=train_size,
                 val_size=val_size,
@@ -46,142 +51,239 @@ def test_simple_split(
             )
         return
 
-    # Initialize splitter
     splitter = ShuffleSplitter(
         train_size=train_size, val_size=val_size, test_size=test_size, random_state=42
     )
 
-    # Generate random data
+    # Generate synthetic random data for testing split logic
     X = np.random.rand(100, 10)
     y = np.random.rand(100)
 
-    # Error is expected
-    if error is True:
-        with pytest.raises(ValueError):
-            splitter.split(X, y)
-        return
-
-    # Perform the split
     X_train, X_val, X_test, y_train, y_val, y_test, groups = splitter.split(X, y)
 
-    # Check train
     assert X_train.shape[0] == expected_train
     assert y_train.shape[0] == expected_train
 
-    # Validation set requested
     if val_size > 0:
         assert X_val.shape[0] == expected_val
         assert y_val.shape[0] == expected_val
+        # Assert X_train and X_val are mutually exclusive
+        train_set = set(map(tuple, X_train))
+        val_set = set(map(tuple, X_val))
+        assert len(train_set.intersection(val_set)) == 0
 
-    # Validation set not requested
     else:
         assert X_val is None
         assert y_val is None
 
-    # Test set requested
     if test_size > 0:
         assert X_test.shape[0] == expected_test
         assert y_test.shape[0] == expected_test
+        # Assert X_train and X_test are mutually exclusive
+        train_set = set(map(tuple, X_train))
+        test_set = set(map(tuple, X_test))
+        assert len(train_set.intersection(test_set)) == 0
 
-    # Test set not requested
+        if val_size > 0:
+            # Assert X_val and X_test are mutually exclusive
+            val_set = set(map(tuple, X_val))
+            assert len(val_set.intersection(test_set)) == 0
+
     else:
         assert X_test is None
         assert y_test is None
+
+
+@pytest.fixture
+def synthetic_cluster_data():
+    """
+    Provide a synthetic dataset with structural diversity for testing cluster splitting.
+
+    This fixture returns a set of SMILES strings representing different chemical scaffolds
+    (benzenes, pyridines, cyclohexanes, furans, thiophenes) and corresponding target values.
+    Using diverse scaffolds ensures that clustering algorithms (like Butina or Bemis-Murcko)
+    can meaningfully group molecules, allowing verification that splits respect cluster boundaries.
+    """
+    base_smiles = [
+        "Cc1ccccc1",
+        "CCc1ccccc1",
+        "Oc1ccccc1",
+        "Nc1ccccc1",
+        "Clc1ccccc1",
+        "Fc1ccccc1",
+        "C(=O)Oc1ccccc1",
+        "C(=O)Cc1ccccc1",
+        "c1ccccc1C#N",
+        "COc1ccccc1",
+        "Cc1ccncc1",
+        "CCc1ccncc1",
+        "Oc1ccncc1",
+        "Nc1ccncc1",
+        "Clc1ccncc1",
+        "Fc1ccncc1",
+        "C(=O)Oc1ccncc1",
+        "C(=O)Cc1ccncc1",
+        "c1ccncc1C#N",
+        "COc1ccncc1",
+        "CC1CCCCC1",
+        "CCC1CCCCC1",
+        "OC1CCCCC1",
+        "NC1CCCCC1",
+        "ClC1CCCCC1",
+        "FC1CCCCC1",
+        "C(=O)OC1CCCCC1",
+        "C(=O)CC1CCCCC1",
+        "C1CCCCC1C#N",
+        "COC1CCCCC1",
+        "Cc1ccoc1",
+        "CCc1ccoc1",
+        "Oc1ccoc1",
+        "Nc1ccoc1",
+        "Clc1ccoc1",
+        "Fc1ccoc1",
+        "C(=O)Oc1ccoc1",
+        "C(=O)Cc1ccoc1",
+        "c1ccoc1C#N",
+        "COc1ccoc1",
+        "Cc1ccsc1",
+        "CCc1ccsc1",
+        "Oc1ccsc1",
+        "Nc1ccsc1",
+        "Clc1ccsc1",
+        "Fc1ccsc1",
+        "C(=O)Oc1ccsc1",
+        "C(=O)Cc1ccsc1",
+        "c1ccsc1C#N",
+        "COc1ccsc1",
+        "Cc1ccc2ccccc2c1",
+        "CCc1ccc2ccccc2c1",
+        "Oc1ccc2ccccc2c1",
+        "Nc1ccc2ccccc2c1",
+        "Clc1ccc2ccccc2c1",
+        "Fc1ccc2ccccc2c1",
+        "C(=O)Oc1ccc2ccccc2c1",
+        "C(=O)Cc1ccc2ccccc2c1",
+        "c1ccc2ccccc2c1C#N",
+        "COc1ccc2ccccc2c1",
+        "Cc1ccc2[nH]ccc2c1",
+        "CCc1ccc2[nH]ccc2c1",
+        "Oc1ccc2[nH]ccc2c1",
+        "Nc1ccc2[nH]ccc2c1",
+        "Clc1ccc2[nH]ccc2c1",
+        "Fc1ccc2[nH]ccc2c1",
+        "C(=O)Oc1ccc2[nH]ccc2c1",
+        "C(=O)Cc1ccc2[nH]ccc2c1",
+        "c1ccc2[nH]ccc2c1C#N",
+        "COc1ccc2[nH]ccc2c1",
+        "Cc1ccc2ncccc2c1",
+        "CCc1ccc2ncccc2c1",
+        "Oc1ccc2ncccc2c1",
+        "Nc1ccc2ncccc2c1",
+        "Clc1ccc2ncccc2c1",
+        "Fc1ccc2ncccc2c1",
+        "C(=O)Oc1ccc2ncccc2c1",
+        "C(=O)Cc1ccc2ncccc2c1",
+        "c1ccc2ncccc2c1C#N",
+        "COc1ccc2ncccc2c1",
+        "CC1CCCC1",
+        "CCC1CCCC1",
+        "OC1CCCC1",
+        "NC1CCCC1",
+        "ClC1CCCC1",
+        "FC1CCCC1",
+        "C(=O)OC1CCCC1",
+        "C(=O)CC1CCCC1",
+        "C1CCCC1C#N",
+        "COC1CCCC1",
+        "CC1CCNCC1",
+        "CCC1CCNCC1",
+        "OC1CCNCC1",
+        "NC1CCNCC1",
+        "ClC1CCNCC1",
+        "FC1CCNCC1",
+        "C(=O)OC1CCNCC1",
+        "C(=O)CC1CCNCC1",
+        "C1CCNCC1C#N",
+        "COC1CCNCC1",
+    ]
+    smiles = pd.Series(base_smiles)
+    y = pd.Series(np.linspace(0.0, 1.0, len(smiles)))
+    return smiles, y
 
 
 @pytest.mark.parametrize(
-    "train_size, val_size, test_size, expected_train, expected_val, expected_test, error, method",
+    "method",
     [
-        # Test cases for kmeans
-        (0.8, 0.0, 0.2, 1600, 0, 400, False, "kmeans"),
-        (0.7, 0.3, 0.0, 1400, 600, 0, False, "kmeans"),
-        (0.7, 0.1, 0.2, 1400, 200, 400, False, "kmeans"),
-        (0.6, 0.2, 0.2, 1200, 400, 400, False, "kmeans"),
-        # Test cases for butina
-        (0.8, 0.0, 0.2, 1600, 0, 400, False, "butina"),
-        (0.7, 0.3, 0.0, 1400, 600, 0, False, "butina"),
-        (0.7, 0.1, 0.2, 1400, 200, 400, False, "butina"),
-        (0.6, 0.2, 0.2, 1200, 400, 400, False, "butina"),
-        # Test cases for bemis-murcko
-        (0.8, 0.0, 0.2, 1600, 0, 400, False, "bemis-murcko"),
-        (0.7, 0.3, 0.0, 1400, 600, 0, False, "bemis-murcko"),
-        (0.7, 0.1, 0.2, 1400, 200, 400, False, "bemis-murcko"),
-        (0.6, 0.2, 0.2, 1200, 400, 400, False, "bemis-murcko"),
-        # Error cases
-        (1.0, 0.0, 0.0, 200, 0, 0, True, "kmeans"),
-        (0.5, 0.5, 0.5, -1, -1, -1, True, "kmeans"),
+        "kmeans",
+        "butina",
+        "bemis-murcko",
     ],
 )
-def test_cluster_split(
-    train_size,
-    val_size,
-    test_size,
-    expected_train,
-    expected_val,
-    expected_test,
-    error,
-    method,
-):
-    df = pd.read_csv(CYP3A4_chembl_pchembl)
-    X = df["CANONICAL_SMILES"][:2000]
-    y = df["pChEMBL mean"][:2000]
+def test_cluster_split_synthetic_data(method, synthetic_cluster_data):
+    """
+    Validate ClusterSplitter functionality with different clustering methods.
 
-    # Error expected
-    if error is True:
-        with pytest.raises(ValueError):
-            # Initialize splitter
-            splitter = ClusterSplitter(
-                train_size=train_size,
-                val_size=val_size,
-                test_size=test_size,
-                random_state=42,
-                method=method,
-                k_clusters=100,
-            )
-        return
-
-    # Initialize splitter
+    This test ensures that molecular data is split such that training, validation, and test sets
+    contain mutually exclusive molecules (no data leakage). It verifies split sizes are approximately
+    correct and that structural separation is maintained.
+    """
+    X, y = synthetic_cluster_data
     splitter = ClusterSplitter(
-        train_size=train_size,
-        val_size=val_size,
-        test_size=test_size,
+        train_size=0.7,
+        val_size=0.1,
+        test_size=0.2,
         random_state=42,
         method=method,
-        k_clusters=100,
+        k_clusters=10,
+    )
+    X_train, X_val, X_test, y_train, y_val, y_test, groups = splitter.split(
+        X, y, num_iters=50
     )
 
-    # Perform the split
-    X_train, X_val, X_test, y_train, y_val, y_test, groups = splitter.split(X, y)
-
-    # Check type preservation
     for obj in [X_train, X_val, X_test]:
         if obj is not None:
-            assert isinstance(obj, pd.Series), "X split must preserve pandas Series"
+            assert isinstance(obj, pd.Series)
 
     for obj in [y_train, y_val, y_test]:
         if obj is not None:
-            assert isinstance(obj, pd.Series), "y split must preserve pandas Series"
+            assert isinstance(obj, pd.Series)
 
-    # Check train
-    assert abs(X_train.shape[0] - expected_train) <= 10
-    assert abs(y_train.shape[0] - expected_train) <= 10
+    total = len(X)
+    assert abs(len(X_train) - int(0.7 * total)) <= 5
+    assert abs(len(X_val) - int(0.1 * total)) <= 5
+    assert abs(len(X_test) - int(0.2 * total)) <= 5
+    assert len(groups) == total
 
-    # Validation set requested
-    if val_size > 0:
-        assert abs(X_val.shape[0] - expected_val) <= 10
-        assert abs(y_val.shape[0] - expected_val) <= 10
+    # Check for data leakage
+    # Assert X_train, X_val, and X_test are mutually exclusive by index
+    train_idx = set(X_train.index)
+    val_idx = set(X_val.index)
+    test_idx = set(X_test.index)
 
-    # Validation set not requested
-    else:
-        assert X_val is None
-        assert y_val is None
+    assert len(train_idx.intersection(val_idx)) == 0
+    assert len(train_idx.intersection(test_idx)) == 0
+    assert len(val_idx.intersection(test_idx)) == 0
 
-    # Test set requested
-    if test_size > 0:
-        assert abs(X_test.shape[0] - expected_test) <= 10
-        assert abs(y_test.shape[0] - expected_test) <= 10
 
-    # Test set not requested
-    else:
-        assert X_test is None
-        assert y_test is None
+def test_cluster_split_invalid_size_configuration():
+    """Ensure ClusterSplitter raises ValueError for invalid split size configurations (e.g., sum != 1.0)."""
+    with pytest.raises(ValueError):
+        ClusterSplitter(
+            train_size=1.0,
+            val_size=0.0,
+            test_size=0.0,
+            random_state=42,
+            method="kmeans",
+        )
+
+
+def test_cluster_split_invalid_method():
+    """Ensure ClusterSplitter raises ValueError when initialized with an unknown clustering method."""
+    with pytest.raises(ValueError):
+        ClusterSplitter(
+            train_size=0.7,
+            val_size=0.1,
+            test_size=0.2,
+            random_state=42,
+            method="not-a-method",
+        )

--- a/openadmet/models/tests/unit/test_data/dummy_null_anvil.yaml
+++ b/openadmet/models/tests/unit/test_data/dummy_null_anvil.yaml
@@ -1,0 +1,42 @@
+metadata:
+  version: v1
+  name: "dummy-null-test"
+  build_number: 0
+  description: "minimal test workflow using NullFeaturizer and DummyRegressorModel"
+  tag: "UNIT"
+  authors: "Test Author"
+  email: "test@test.com"
+  biotargets:
+    - "test"
+  tags:
+    - "test"
+
+data:
+  type: csv
+  resource: "{{ANVIL_DIR}}/test_data.csv"
+  input_col: "SMILES"
+  target_cols: ["data1"]
+
+procedure:
+  split:
+    type: ShuffleSplitter
+    params:
+      train_size: 0.8
+      test_size: 0.2
+      random_state: 42
+
+  feat:
+    type: NullFeaturizer
+    params: {}
+
+  model:
+    type: DummyRegressorModel
+    params: {}
+
+  train:
+    type: SKLearnBasicTrainer
+    params: {}
+
+report:
+  eval:
+    - type: RegressionMetrics

--- a/openadmet/models/tests/unit/test_data/dummy_null_anvil.yaml
+++ b/openadmet/models/tests/unit/test_data/dummy_null_anvil.yaml
@@ -40,3 +40,5 @@ procedure:
 report:
   eval:
     - type: RegressionMetrics
+      params:
+        n_resamples: 100

--- a/openadmet/models/tests/unit/test_utils.py
+++ b/openadmet/models/tests/unit/test_utils.py
@@ -2,6 +2,12 @@ import traceback
 
 
 def click_success(result):
+    """
+    Helper function to verify that a Click command executed successfully (exit code 0).
+
+    If the command failed, this function prints the output and traceback to aid in debugging
+    before returning False.
+    """
     if result.exit_code != 0:  # -no-cov-  (only occurs on test error)
         print(result.output)
         traceback.print_tb(result.exc_info[2])


### PR DESCRIPTION
## Description
Applies the new unit testing standards (introduced in #534) across the remainder of the unit test suite.

## Changes
 
 - **`test_cli.py`** — Replace integration-style subprocess calls with direct function invocation; `mocker`-based patching for I/O side effects
 - **`test_comparison.py`** — Strengthen float assertions with `pytest.approx()`; adopt updated `levene["stat"]` dict key from posthoc refactor
 - **`test_data.py`** — Add missing docstrings; strengthen assertions
 - **`test_eval.py`** — Add docstrings; strengthen existing assertions (preserves RAE/log-unit metric tests from main)
 - **`test_features.py`** — Add mutual-exclusion checks on feature outputs; remove `MagicMock` on system under test
 - **`test_nepare.py`** — Add missing docstrings
 - **`test_inference.py`** — Full rewrite: real lightweight components,`pytest-mock` for side effects only, `isinstance` guards on outputs
 - **`test_base.py`** — Add missing docstrings (preserves `weights_only` load test from main)
 - **`test_lgbm.py`** — Add docstrings; strengthen assertions with `pytest.approx()`
 - **`test_splitters.py`** — Add mutual-exclusion assertions on all split strategies; diverse synthetic SMILES for scaffold/cluster splits

## Quality Assurance & AI Policy
To maintain project quality and respect maintainer bandwidth, please confirm the following:

- [x] **Manual Verification:** I have manually reviewed and tested the code in this PR.
- [x] **AI-Assisted Content:** If AI tools were used (e.g., Copilot, ChatGPT), I have personally verified the logic, edge cases, and compliance with the existing codebase. I confirm the code is not a "blind" AI generation.
- [x] **Minimal Review:** I believe this PR is in a state that requires minimal intervention or correction from maintainers.
- [x] **Scoped Change:** This PR addresses a single, well-scoped issue rather than multiple unrelated changes.

## Status
- [x] Ready to go (Checking this signals to maintainers that the PR is ready for final review)

## Developers Certificate of Origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenADMET/openadmet_toolkit/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.

---
**Note to Contributors:** We reserve the right to close PRs without review if they appear to lack human validation or do not meet the quality standards described in our `CONTRIBUTING.md`.
