### PR TITLE
Expose n_resamples on EvalBase to make bootstrap CI cost configurable

### DIFF
--- a/openadmet/models/eval/eval_base.py
+++ b/openadmet/models/eval/eval_base.py
@@ -6,7 +6,7 @@ from typing import Callable, ClassVar
 from loguru import logger
 import numpy as np
 from class_registry import ClassRegistry, RegistryKeyError
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from scipy.stats import bootstrap
 
 evaluators = ClassRegistry(unique=True)
@@ -145,9 +145,25 @@ def get_t_true_and_t_pred(task_id, y_true, y_pred, y_val=None, y_pred_fold=None)
 
 
 class EvalBase(BaseModel):
-    """Abstract base class for evaluation modules."""
+    """
+    Abstract base class for evaluation modules.
+
+    Attributes
+    ----------
+    n_resamples : int
+        Number of bootstrap resamples used to estimate confidence intervals.
+        Defaults to 9999 (scipy default). Lower values (e.g. 100) are appropriate
+        for unit tests where CI precision is not required.
+
+    """
 
     is_cross_val: ClassVar[bool] = False
+
+    n_resamples: int = Field(
+        default=9999,
+        ge=1,
+        description="Number of bootstrap resamples for confidence interval estimation",
+    )
 
     class Config:
         """Pydantic configuration for the EvalBase class."""
@@ -244,6 +260,7 @@ class EvalBase(BaseModel):
                 statistic=lambda y_true, y_pred: statistic(y_true, y_pred).statistic,
                 method="basic",
                 confidence_level=confidence_level,
+                n_resamples=self.n_resamples,
                 paired=True,
             ).confidence_interval
 
@@ -254,6 +271,7 @@ class EvalBase(BaseModel):
                 statistic=statistic,
                 method="basic",
                 confidence_level=confidence_level,
+                n_resamples=self.n_resamples,
                 paired=True,
             ).confidence_interval
 

--- a/openadmet/models/tests/unit/eval/test_eval.py
+++ b/openadmet/models/tests/unit/eval/test_eval.py
@@ -29,7 +29,7 @@ def test_regression_metrics():
     y_true = np.array([3, -0.5, 2, 7]).reshape(-1, 1)
     y_pred = np.array([2.5, 0.0, 2, 8]).reshape(-1, 1)
 
-    rm = RegressionMetrics()
+    rm = RegressionMetrics(n_resamples=100)
     metrics = rm.evaluate(y_true, y_pred)
 
     assert metrics["task_0"]["mse"]["value"] == 0.375
@@ -110,7 +110,7 @@ def test_classification_metrics():
     # Classes would be [0, 1, 1, 1]
     y_pred = [[1, 0], [0, 1], [0, 1], [0, 1]]
 
-    cm = ClassificationMetrics()
+    cm = ClassificationMetrics(n_resamples=100)
     metrics = cm.evaluate(y_true, y_pred)
 
     assert metrics["accuracy"]["value"] == 0.75


### PR DESCRIPTION
## Description
`EvalBase.stat_and_bootstrap` called `scipy.stats.bootstrap` with a hardcoded default of `n_resamples=9999`, causing ~60,000 bootstrap iterations on toy 4-element test data across 6 classification metrics. This results in `test_classification_metrics` taking ~18s with no way to reduce it from outside the class. 

Closes #555.
 
 ## Changes
 
 ### `openadmet/models/eval/eval_base.py`
 - Added `Field` to pydantic imports
 - Added `n_resamples: int = Field(default=9999, ge=1)` to `EvalBase`; default preserves existing production behavior
 - Passed `n_resamples=self.n_resamples` to both `bootstrap()` calls in `stat_and_bootstrap`
 
 ### `openadmet/models/tests/unit/eval/test_eval.py`
 - Instantiate `ClassificationMetrics(n_resamples=100)` and `RegressionMetrics(n_resamples=100)` in metric tests (CI precision is not under test there)
 
 ## Performance
 | Test | Before | After |
 |---|---|---|
 | `test_classification_metrics` | ~18.6s | ~0.18s |
 | `test_regression_metrics` | ~4.4s | ~0.04s |

## Quality Assurance & AI Policy
To maintain project quality and respect maintainer bandwidth, please confirm the following:

- [x] **Manual Verification:** I have manually reviewed and tested the code in this PR.
- [x] **AI-Assisted Content:** If AI tools were used (e.g., Copilot, ChatGPT), I have personally verified the logic, edge cases, and compliance with the existing codebase. I confirm the code is not a "blind" AI generation.
- [x] **Minimal Review:** I believe this PR is in a state that requires minimal intervention or correction from maintainers.
- [x] **Scoped Change:** This PR addresses a single, well-scoped issue rather than multiple unrelated changes.

## Status
- [x] Ready to go (Checking this signals to maintainers that the PR is ready for final review)

## Developers Certificate of Origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenADMET/openadmet_toolkit/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.

---
**Note to Contributors:** We reserve the right to close PRs without review if they appear to lack human validation or do not meet the quality standards described in our `CONTRIBUTING.md`.
