### PR TITLE
Extend ANVIL_DIR templating to procedure block

### DIFF
--- a/openadmet/models/anvil/specification.py
+++ b/openadmet/models/anvil/specification.py
@@ -144,7 +144,9 @@ class DataSpec(BaseModel):
             value = getattr(self, attr, None)
             if value:
                 rendered = jinja2.Template(value).render(ANVIL_DIR=anvil_dir)
-                print(f"[DEBUG DataSpec.template_anvil_dir] {attr}: {value!r} -> {rendered!r}")
+                print(
+                    f"[DEBUG DataSpec.template_anvil_dir] {attr}: {value!r} -> {rendered!r}"
+                )
                 setattr(self, attr, rendered)
             else:
                 print(f"[DEBUG DataSpec.template_anvil_dir] {attr}: not set, skipping")
@@ -548,7 +550,9 @@ class ModelSpec(AnvilSection):
             value = getattr(self, attr, None)
             if value:
                 rendered = jinja2.Template(value).render(ANVIL_DIR=anvil_dir)
-                print(f"[DEBUG ModelSpec.template_anvil_dir] {attr}: {value!r} -> {rendered!r}")
+                print(
+                    f"[DEBUG ModelSpec.template_anvil_dir] {attr}: {value!r} -> {rendered!r}"
+                )
                 setattr(self, attr, rendered)
             else:
                 print(f"[DEBUG ModelSpec.template_anvil_dir] {attr}: not set, skipping")
@@ -631,11 +635,17 @@ class EnsembleSpec(AnvilSection):
         for attr in ["param_paths", "serial_paths"]:
             values = getattr(self, attr, None)
             if values:
-                rendered = [jinja2.Template(v).render(ANVIL_DIR=anvil_dir) for v in values]
-                print(f"[DEBUG EnsembleSpec.template_anvil_dir] {attr}: {values!r} -> {rendered!r}")
+                rendered = [
+                    jinja2.Template(v).render(ANVIL_DIR=anvil_dir) for v in values
+                ]
+                print(
+                    f"[DEBUG EnsembleSpec.template_anvil_dir] {attr}: {values!r} -> {rendered!r}"
+                )
                 setattr(self, attr, rendered)
             else:
-                print(f"[DEBUG EnsembleSpec.template_anvil_dir] {attr}: not set, skipping")
+                print(
+                    f"[DEBUG EnsembleSpec.template_anvil_dir] {attr}: not set, skipping"
+                )
 
 
 class TrainerSpec(AnvilSection):

--- a/openadmet/models/anvil/specification.py
+++ b/openadmet/models/anvil/specification.py
@@ -536,6 +536,13 @@ class ModelSpec(AnvilSection):
 
         return self
 
+    def template_anvil_dir(self, anvil_dir: Path):
+        """Template param_path and serial_path with ANVIL_DIR."""
+        for attr in ["param_path", "serial_path"]:
+            value = getattr(self, attr, None)
+            if value:
+                setattr(self, attr, jinja2.Template(value).render(ANVIL_DIR=anvil_dir))
+
 
 class EnsembleSpec(AnvilSection):
     """
@@ -608,6 +615,17 @@ class EnsembleSpec(AnvilSection):
             "Both `param_paths` and `serial_paths` must be provided together."
         )
 
+    def template_anvil_dir(self, anvil_dir: Path):
+        """Template param_paths and serial_paths with ANVIL_DIR."""
+        for attr in ["param_paths", "serial_paths"]:
+            values = getattr(self, attr, None)
+            if values:
+                setattr(
+                    self,
+                    attr,
+                    [jinja2.Template(v).render(ANVIL_DIR=anvil_dir) for v in values],
+                )
+
 
 class TrainerSpec(AnvilSection):
     """Trainer specification."""
@@ -638,6 +656,12 @@ class ProcedureSpec(SpecBase):
     ensemble: EnsembleSpec | None = None
     train: TrainerSpec
     transform: Optional[TransformSpec] = None  # Optional transform step
+
+    def template_anvil_dir(self, anvil_dir: Path):
+        """Template ANVIL_DIR in model and ensemble path fields."""
+        self.model.template_anvil_dir(anvil_dir)
+        if self.ensemble is not None:
+            self.ensemble.template_anvil_dir(anvil_dir)
 
 
 class ReportSpec(SpecBase):
@@ -671,6 +695,7 @@ class AnvilSpecification(BaseModel):
 
         # Set the anvil_dir
         instance.data.template_anvil_dir(parent)
+        instance.procedure.template_anvil_dir(parent)
 
         return instance
 

--- a/openadmet/models/anvil/specification.py
+++ b/openadmet/models/anvil/specification.py
@@ -138,11 +138,16 @@ class DataSpec(BaseModel):
     def template_anvil_dir(self, anvil_dir: Path):
         """Template all resources with ANVIL_DIR if present."""
         self.anvil_dir = anvil_dir
+        print(f"[DEBUG DataSpec.template_anvil_dir] anvil_dir={anvil_dir!r}")
 
         for attr in ["resource", "train_resource", "test_resource", "val_resource"]:
             value = getattr(self, attr, None)
             if value:
-                setattr(self, attr, jinja2.Template(value).render(ANVIL_DIR=anvil_dir))
+                rendered = jinja2.Template(value).render(ANVIL_DIR=anvil_dir)
+                print(f"[DEBUG DataSpec.template_anvil_dir] {attr}: {value!r} -> {rendered!r}")
+                setattr(self, attr, rendered)
+            else:
+                print(f"[DEBUG DataSpec.template_anvil_dir] {attr}: not set, skipping")
 
     def read(self) -> tuple[pd.Series, pd.Series]:
         """
@@ -538,10 +543,15 @@ class ModelSpec(AnvilSection):
 
     def template_anvil_dir(self, anvil_dir: Path):
         """Template param_path and serial_path with ANVIL_DIR."""
+        print(f"[DEBUG ModelSpec.template_anvil_dir] anvil_dir={anvil_dir!r}")
         for attr in ["param_path", "serial_path"]:
             value = getattr(self, attr, None)
             if value:
-                setattr(self, attr, jinja2.Template(value).render(ANVIL_DIR=anvil_dir))
+                rendered = jinja2.Template(value).render(ANVIL_DIR=anvil_dir)
+                print(f"[DEBUG ModelSpec.template_anvil_dir] {attr}: {value!r} -> {rendered!r}")
+                setattr(self, attr, rendered)
+            else:
+                print(f"[DEBUG ModelSpec.template_anvil_dir] {attr}: not set, skipping")
 
 
 class EnsembleSpec(AnvilSection):
@@ -617,14 +627,15 @@ class EnsembleSpec(AnvilSection):
 
     def template_anvil_dir(self, anvil_dir: Path):
         """Template param_paths and serial_paths with ANVIL_DIR."""
+        print(f"[DEBUG EnsembleSpec.template_anvil_dir] anvil_dir={anvil_dir!r}")
         for attr in ["param_paths", "serial_paths"]:
             values = getattr(self, attr, None)
             if values:
-                setattr(
-                    self,
-                    attr,
-                    [jinja2.Template(v).render(ANVIL_DIR=anvil_dir) for v in values],
-                )
+                rendered = [jinja2.Template(v).render(ANVIL_DIR=anvil_dir) for v in values]
+                print(f"[DEBUG EnsembleSpec.template_anvil_dir] {attr}: {values!r} -> {rendered!r}")
+                setattr(self, attr, rendered)
+            else:
+                print(f"[DEBUG EnsembleSpec.template_anvil_dir] {attr}: not set, skipping")
 
 
 class TrainerSpec(AnvilSection):
@@ -659,6 +670,11 @@ class ProcedureSpec(SpecBase):
 
     def template_anvil_dir(self, anvil_dir: Path):
         """Template ANVIL_DIR in model and ensemble path fields."""
+        # Model paths are opened with plain open(), not fsspec — strip file:// so
+        # the stored strings are valid filesystem paths.
+        anvil_dir_str = str(anvil_dir)
+        if anvil_dir_str.startswith("file://"):
+            anvil_dir = Path(anvil_dir_str[len("file://") :])
         self.model.template_anvil_dir(anvil_dir)
         if self.ensemble is not None:
             self.ensemble.template_anvil_dir(anvil_dir)

--- a/openadmet/models/anvil/specification.py
+++ b/openadmet/models/anvil/specification.py
@@ -659,11 +659,11 @@ class ProcedureSpec(SpecBase):
 
     def template_anvil_dir(self, anvil_dir: Path):
         """Template ANVIL_DIR in model and ensemble path fields."""
-        # Model paths are opened with plain open(), not fsspec — strip file:// so
-        # the stored strings are valid filesystem paths.
-        anvil_dir_str = str(anvil_dir)
-        if anvil_dir_str.startswith("file://"):
-            anvil_dir = Path(anvil_dir_str[len("file://") :])
+        # Model paths are consumed by plain open(), not fsspec — use url_to_fs to
+        # strip any protocol prefix (e.g. file://) so the stored strings are valid
+        # local filesystem paths.
+        _, local_path = fsspec.url_to_fs(str(anvil_dir))
+        anvil_dir = Path(local_path)
         self.model.template_anvil_dir(anvil_dir)
         if self.ensemble is not None:
             self.ensemble.template_anvil_dir(anvil_dir)

--- a/openadmet/models/anvil/specification.py
+++ b/openadmet/models/anvil/specification.py
@@ -138,18 +138,11 @@ class DataSpec(BaseModel):
     def template_anvil_dir(self, anvil_dir: Path):
         """Template all resources with ANVIL_DIR if present."""
         self.anvil_dir = anvil_dir
-        print(f"[DEBUG DataSpec.template_anvil_dir] anvil_dir={anvil_dir!r}")
 
         for attr in ["resource", "train_resource", "test_resource", "val_resource"]:
             value = getattr(self, attr, None)
             if value:
-                rendered = jinja2.Template(value).render(ANVIL_DIR=anvil_dir)
-                print(
-                    f"[DEBUG DataSpec.template_anvil_dir] {attr}: {value!r} -> {rendered!r}"
-                )
-                setattr(self, attr, rendered)
-            else:
-                print(f"[DEBUG DataSpec.template_anvil_dir] {attr}: not set, skipping")
+                setattr(self, attr, jinja2.Template(value).render(ANVIL_DIR=anvil_dir))
 
     def read(self) -> tuple[pd.Series, pd.Series]:
         """
@@ -545,17 +538,10 @@ class ModelSpec(AnvilSection):
 
     def template_anvil_dir(self, anvil_dir: Path):
         """Template param_path and serial_path with ANVIL_DIR."""
-        print(f"[DEBUG ModelSpec.template_anvil_dir] anvil_dir={anvil_dir!r}")
         for attr in ["param_path", "serial_path"]:
             value = getattr(self, attr, None)
             if value:
-                rendered = jinja2.Template(value).render(ANVIL_DIR=anvil_dir)
-                print(
-                    f"[DEBUG ModelSpec.template_anvil_dir] {attr}: {value!r} -> {rendered!r}"
-                )
-                setattr(self, attr, rendered)
-            else:
-                print(f"[DEBUG ModelSpec.template_anvil_dir] {attr}: not set, skipping")
+                setattr(self, attr, jinja2.Template(value).render(ANVIL_DIR=anvil_dir))
 
 
 class EnsembleSpec(AnvilSection):
@@ -631,20 +617,13 @@ class EnsembleSpec(AnvilSection):
 
     def template_anvil_dir(self, anvil_dir: Path):
         """Template param_paths and serial_paths with ANVIL_DIR."""
-        print(f"[DEBUG EnsembleSpec.template_anvil_dir] anvil_dir={anvil_dir!r}")
         for attr in ["param_paths", "serial_paths"]:
             values = getattr(self, attr, None)
             if values:
-                rendered = [
-                    jinja2.Template(v).render(ANVIL_DIR=anvil_dir) for v in values
-                ]
-                print(
-                    f"[DEBUG EnsembleSpec.template_anvil_dir] {attr}: {values!r} -> {rendered!r}"
-                )
-                setattr(self, attr, rendered)
-            else:
-                print(
-                    f"[DEBUG EnsembleSpec.template_anvil_dir] {attr}: not set, skipping"
+                setattr(
+                    self,
+                    attr,
+                    [jinja2.Template(v).render(ANVIL_DIR=anvil_dir) for v in values],
                 )
 
 

--- a/openadmet/models/anvil/workflow.py
+++ b/openadmet/models/anvil/workflow.py
@@ -26,6 +26,13 @@ def _safe_to_numpy(X):
     return X
 
 
+def _as_local_path(p: str) -> Path:
+    """Strip file:// protocol prefix so Path() resolves correctly."""
+    if isinstance(p, str) and p.startswith("file://"):
+        return Path(p[len("file://") :])
+    return Path(p)
+
+
 class AnvilWorkflow(AnvilWorkflowBase):
     """Workflow for running basic Anvil configuration."""
 
@@ -487,9 +494,9 @@ class AnvilDeepLearningWorkflow(AnvilWorkflowBase):
                     "Both param_path and serial_path must be provided together for finetuning."
                 )
             if param_path is not None:
-                if not Path(param_path).exists():
+                if not _as_local_path(param_path).exists():
                     raise ValueError(f"param_path '{param_path}' does not exist.")
-                if not Path(serial_path).exists():
+                if not _as_local_path(serial_path).exists():
                     raise ValueError(f"serial_path '{serial_path}' does not exist.")
         else:
             param_paths = self.ensemble_kwargs.get("param_paths")
@@ -504,10 +511,10 @@ class AnvilDeepLearningWorkflow(AnvilWorkflowBase):
                         "param_paths and serial_paths must have equal length."
                     )
                 for p in param_paths:
-                    if not Path(p).exists():
+                    if not _as_local_path(p).exists():
                         raise ValueError(f"param_path '{p}' does not exist.")
                 for s in serial_paths:
-                    if not Path(s).exists():
+                    if not _as_local_path(s).exists():
                         raise ValueError(f"serial_path '{s}' does not exist.")
         return self
 

--- a/openadmet/models/anvil/workflow.py
+++ b/openadmet/models/anvil/workflow.py
@@ -26,12 +26,6 @@ def _safe_to_numpy(X):
     return X
 
 
-def _as_local_path(p: str) -> Path:
-    """Strip file:// protocol prefix so Path() resolves correctly."""
-    if isinstance(p, str) and p.startswith("file://"):
-        return Path(p[len("file://") :])
-    return Path(p)
-
 
 class AnvilWorkflow(AnvilWorkflowBase):
     """Workflow for running basic Anvil configuration."""
@@ -494,9 +488,9 @@ class AnvilDeepLearningWorkflow(AnvilWorkflowBase):
                     "Both param_path and serial_path must be provided together for finetuning."
                 )
             if param_path is not None:
-                if not _as_local_path(param_path).exists():
+                if not Path(param_path).exists():
                     raise ValueError(f"param_path '{param_path}' does not exist.")
-                if not _as_local_path(serial_path).exists():
+                if not Path(serial_path).exists():
                     raise ValueError(f"serial_path '{serial_path}' does not exist.")
         else:
             param_paths = self.ensemble_kwargs.get("param_paths")
@@ -511,10 +505,10 @@ class AnvilDeepLearningWorkflow(AnvilWorkflowBase):
                         "param_paths and serial_paths must have equal length."
                     )
                 for p in param_paths:
-                    if not _as_local_path(p).exists():
+                    if not Path(p).exists():
                         raise ValueError(f"param_path '{p}' does not exist.")
                 for s in serial_paths:
-                    if not _as_local_path(s).exists():
+                    if not Path(s).exists():
                         raise ValueError(f"serial_path '{s}' does not exist.")
         return self
 

--- a/openadmet/models/anvil/workflow.py
+++ b/openadmet/models/anvil/workflow.py
@@ -26,7 +26,6 @@ def _safe_to_numpy(X):
     return X
 
 
-
 class AnvilWorkflow(AnvilWorkflowBase):
     """Workflow for running basic Anvil configuration."""
 


### PR DESCRIPTION
## Summary

- `{{ANVIL_DIR}}` was only resolved in the `data` block; `param_path` / `serial_path` in `procedure.model` and `procedure.ensemble` were left as raw template strings
- Added `template_anvil_dir` methods to `ModelSpec`, `EnsembleSpec`, and `ProcedureSpec`
- `AnvilSpecification.from_recipe` now calls `instance.procedure.template_anvil_dir(parent)` alongside the existing `instance.data.template_anvil_dir(parent)`

## Test plan

- [x] Existing `test_specification.py` tests pass
- [x] Load a recipe with `{{ANVIL_DIR}}` in `procedure.model.param_path` / `serial_path` and confirm paths are resolved correctly
- [x] Load a recipe with `{{ANVIL_DIR}}` in `procedure.ensemble.param_paths` / `serial_paths` and confirm all list entries are resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)