### PR TITLE
fix: remove unused MoleculeTransformer import from transform_base.py

### DIFF
--- a/openadmet/models/transforms/transform_base.py
+++ b/openadmet/models/transforms/transform_base.py
@@ -5,7 +5,6 @@ from collections.abc import Iterable
 
 import numpy as np
 from class_registry import ClassRegistry, RegistryKeyError
-from molfeat.trans import MoleculeTransformer
 from pydantic import BaseModel
 from sklearn.preprocessing import StandardScaler
 from torch.utils.data import DataLoader, Dataset


### PR DESCRIPTION
## Summary

- Removes the unused `from molfeat.trans import MoleculeTransformer` import from `openadmet/models/transforms/transform_base.py`
- `MoleculeTransformer` is imported at module level but never referenced anywhere in the file
- This dead import was missed when the deferred imports PR (#552) was merged

## Why this matters

The deferred imports PR (#552) moved heavy third-party imports (molfeat, mordredcommunity, pmapper, etc.) behind lazy loaders to improve import times. However, this unused import in `transform_base.py` still pulled in the full molfeat dependency chain at module level on every import of `openadmet.models.transforms.transform_base`, negating the benefit.

## Test plan

- [ ] Verify `from openadmet.models.transforms.transform_base import get_transform_class` works without molfeat installed
- [ ] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)