### PR TITLE
fix: convert numpy float32 to Python native types before JSON serialization

### DIFF
--- a/openadmet/models/eval/uncertainty.py
+++ b/openadmet/models/eval/uncertainty.py
@@ -3,6 +3,7 @@
 import json
 
 import matplotlib.pyplot as plt
+import numpy as np
 import pandas as pd
 import uncertainty_toolbox as uct
 import wandb
@@ -230,7 +231,12 @@ class UncertaintyMetrics(EvalBase):
         # Write to JSON
         json_path = output_dir / "uncertainty_calibration_metrics.json"
         with open(json_path, "w") as f:
-            json.dump(self._data, f, indent=2)
+            json.dump(
+                self._data,
+                f,
+                indent=2,
+                default=lambda o: o.item() if isinstance(o, np.generic) else o,
+            )
 
         # Also log the JSON to wandb
         if self.use_wandb:


### PR DESCRIPTION
## Summary
- `uncertainty_toolbox` returns `numpy.float32` metric values which `json.dump` cannot serialize
- This caused the `chemeleon_MT_ensemble` GPU integration test to fail with `TypeError: Object of type float32 is not JSON serializable`
- Fix uses `np.generic.item()` as a `json.dump` default handler to convert any numpy scalar to its Python native equivalent

## Test plan
- [ ] Run `test_gpu_configs[chemeleon_MT_ensemble]` GPU integration test to confirm it passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)