### PR TITLE
Reset weights_only foundation model load to true

### DIFF
--- a/openadmet/models/architecture/chemprop.py
+++ b/openadmet/models/architecture/chemprop.py
@@ -556,7 +556,7 @@ class ChemPropModel(LightningModelBase):
             )
         else:
             logger.info(f"Loading cached CheMeleon from {model_path}")
-        return torch.load(model_path, weights_only=False)
+        return torch.load(model_path, weights_only=True)
 
     def _load_foundation_model(self, model_path: Path) -> dict:
         """
@@ -575,7 +575,7 @@ class ChemPropModel(LightningModelBase):
         """
         if not model_path.exists():
             raise FileNotFoundError(f"Foundation model not found at {model_path}")
-        return torch.load(model_path, weights_only=False)
+        return torch.load(model_path, weights_only=True)
 
     def train(self, dataloader, scaler=None):
         """


### PR DESCRIPTION
## Description
I changed weights_only to False because of how I was saving my foundation model .pt files. I fixed this now, resetting to the old, more secure way of doing this.

## Quality Assurance & AI Policy
To maintain project quality and respect maintainer bandwidth, please confirm the following:

- [ x] **Manual Verification:** I have manually reviewed and tested the code in this PR.
- [ x] **AI-Assisted Content:** If AI tools were used (e.g., Copilot, ChatGPT), I have personally verified the logic, edge cases, and compliance with the existing codebase. I confirm the code is not a "blind" AI generation.
- [x ] **Minimal Review:** I believe this PR is in a state that requires minimal intervention or correction from maintainers.
- [x ] **Scoped Change:** This PR addresses a single, well-scoped issue rather than multiple unrelated changes.

## Status
- [ x] Ready to go (Checking this signals to maintainers that the PR is ready for final review)

## Developers Certificate of Origin
- [ x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenADMET/openadmet_toolkit/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.

---
**Note to Contributors:** We reserve the right to close PRs without review if they appear to lack human validation or do not meet the quality standards described in our `CONTRIBUTING.md`.
