### PR TITLE
Make shuffle and drop_last training-only across deep-learning workflows

### DIFF
--- a/openadmet/models/anvil/workflow.py
+++ b/openadmet/models/anvil/workflow.py
@@ -614,6 +614,7 @@ class AnvilDeepLearningWorkflow(AnvilWorkflowBase):
                 self.feat.featurize(
                     X_train_bootstrap,
                     y_train_bootstrap,
+                    train=True,
                 )
             )
 
@@ -786,6 +787,7 @@ class AnvilDeepLearningWorkflow(AnvilWorkflowBase):
         train_dataloader, _, train_scaler, train_dataset = self.feat.featurize(
             X_train,
             y_train,
+            train=True,
         )
         torch.save(train_dataloader, output_dir / "train_dataloader.pth")
 

--- a/openadmet/models/eval/cross_validation.py
+++ b/openadmet/models/eval/cross_validation.py
@@ -663,7 +663,7 @@ class PytorchLightningRepeatedKFoldCrossValidation(CrossValidationBase):
             fold_featurizer = featurizer.make_new()
 
             fold_train_dataloader, _, fold_train_scaler, _ = fold_featurizer.featurize(
-                X_train, y_train
+                X_train, y_train, train=True
             )
 
             fold_val_dataloader, _, _, _ = fold_featurizer.featurize(X_val, y_val)

--- a/openadmet/models/features/chemprop.py
+++ b/openadmet/models/features/chemprop.py
@@ -21,6 +21,7 @@ def _vendor_build_dataloader(
     sampler: Any = None,
     seed: int | None = None,
     shuffle: bool = True,
+    drop_last_on_singleton: bool = True,
     **kwargs,
 ):
     r"""
@@ -47,6 +48,9 @@ def _vendor_build_dataloader(
         Whether to shuffle the data at every epoch. If a sampler is specified, this is ignored
         (i.e., the sampler determines the shuffling). If class_balance is True, this is also ignored
         (i.e., class balancing determines the shuffling).
+    drop_last_on_singleton : bool, default=True
+        Whether to drop a size-1 final batch (when ``len(dataset) % batch_size == 1``) to avoid
+        batch-norm errors. Set False for evaluation and inference loaders so every row is returned.
     **kwargs
         Additional keyword arguments passed to the DataLoader.
 
@@ -61,7 +65,7 @@ def _vendor_build_dataloader(
     from chemprop.data.samplers import ClassBalanceSampler, SeededSampler
     from torch.utils.data import DataLoader
 
-    if sampler is not None:
+    if sampler is None:
         if class_balance:
             sampler = ClassBalanceSampler(dataset.Y, seed, shuffle)
         elif shuffle and seed is not None:
@@ -74,11 +78,8 @@ def _vendor_build_dataloader(
     else:
         collate_fn = collate_batch
 
-    # Drop last batch of size 1 to avoid issues with batch normalization
-    if len(dataset) % batch_size == 1:
-        drop_last = True
-    else:
-        drop_last = False
+    # Drop a size-1 final batch only when requested (training), to avoid batch-norm errors
+    drop_last = drop_last_on_singleton and len(dataset) % batch_size == 1
 
     return DataLoader(
         dataset,
@@ -119,7 +120,7 @@ class ChemPropFeaturizer(DeepLearningFeaturizer):
         """Prepare the featurizer."""
 
     def featurize(
-        self, smiles: Iterable[str], y: Iterable[Any] = None
+        self, smiles: Iterable[str], y: Iterable[Any] = None, train: bool = False
     ) -> tuple[
         DataLoader,
         np.ndarray,
@@ -135,6 +136,10 @@ class ChemPropFeaturizer(DeepLearningFeaturizer):
             List or iterable of SMILES strings to featurize.
         y : Iterable[Any], optional
             Target values corresponding to the SMILES strings.
+        train : bool, optional
+            Whether this loader feeds model training, by default False. Shuffling and the
+            batch-norm ``drop_last`` guard apply only when True; otherwise the loader
+            preserves input order and returns every row.
 
         Returns
         -------
@@ -167,11 +172,14 @@ class ChemPropFeaturizer(DeepLearningFeaturizer):
             )
             scaler = None
 
+        # Shuffle and the size-1 drop_last guard are training-only; evaluation and
+        # inference loaders preserve input order and length for correct y_true/y_pred pairing
         dataloader = self.dataset_to_dataloader(
             dataset,
             num_workers=self.n_jobs,
-            shuffle=self.shuffle,
+            shuffle=self.shuffle and train,
             batch_size=self.batch_size,
+            drop_last_on_singleton=train,
         )
 
         # Need to also return an index of the original input for which the features were computed

--- a/openadmet/models/features/feature_base.py
+++ b/openadmet/models/features/feature_base.py
@@ -94,7 +94,7 @@ class DeepLearningFeaturizer(FeaturizerBase):
 
     @abstractmethod
     def featurize(
-        self, smiles: Iterable[str], y: Iterable[float] = None
+        self, smiles: Iterable[str], y: Iterable[float] = None, train: bool = False
     ) -> tuple[DataLoader, np.ndarray, StandardScaler, Dataset]:
         """
         Featurize a list of SMILES strings for deep learning models.
@@ -105,6 +105,10 @@ class DeepLearningFeaturizer(FeaturizerBase):
             List or iterable of SMILES strings to featurize.
         y : Iterable[float], optional
             Target values corresponding to the SMILES strings.
+        train : bool, optional
+            Whether this loader feeds model training, by default False. Shuffling and
+            the batch-norm ``drop_last`` guard apply only when True; validation, test,
+            and inference loaders (train=False) always preserve input order and length.
 
         Returns
         -------

--- a/openadmet/models/features/pairwise.py
+++ b/openadmet/models/features/pairwise.py
@@ -133,6 +133,7 @@ class PairwiseFeaturizer(FeaturizerBase):
         self,
         smiles: ArrayLike,
         y: ArrayLike = None,
+        train: bool = False,
     ) -> tuple[DataLoader, np.ndarray, StandardScaler, Dataset]:
         """
         Featurize a list of SMILES strings.
@@ -145,6 +146,10 @@ class PairwiseFeaturizer(FeaturizerBase):
             A list or array of SMILES strings to featurize
         y: ArrayLike, optional
             A list or array of target values to pair with the features
+        train: bool, optional
+            Whether this loader feeds model training, by default False. Shuffling and the
+            size-1 ``drop_last`` guard apply only when True; otherwise the loader preserves
+            input order and returns every row.
 
         Returns
         -------
@@ -172,11 +177,14 @@ class PairwiseFeaturizer(FeaturizerBase):
 
         paired_dataset = PairwiseAugmentedDataset(X_feat, y, how=self.how_to_pair)
 
+        # Shuffle and the size-1 drop_last guard are training-only; evaluation and
+        # inference loaders preserve input order and length for correct y_true/y_pred pairing
         dataloader = DataLoader(
             paired_dataset,
             batch_size=self.batch_size,
-            shuffle=self.shuffle,
+            shuffle=self.shuffle and train,
             num_workers=self.n_jobs,
+            drop_last=(train and len(paired_dataset) % self.batch_size == 1),
         )
 
         indices = np.arange(len(paired_dataset.X))

--- a/openadmet/models/inference/inference.py
+++ b/openadmet/models/inference/inference.py
@@ -66,7 +66,8 @@ def load_anvil_model_and_metadata(model_dir):
     # Load the procedure specification
     procedure_spec = ProcedureSpec.from_yaml(procedure_spec)
     feat = procedure_spec.feat.to_class()
-    # Training-time shuffle must not apply at inference: output order must match input order
+    # Defense-in-depth: inference featurizes with train=False, so shuffle and drop_last
+    # are already disabled; pin shuffle off as well in case the featurizer is reused directly
     if hasattr(feat, "shuffle"):
         feat.shuffle = False
     model = procedure_spec.model.to_class()

--- a/openadmet/models/tests/unit/features/test_features.py
+++ b/openadmet/models/tests/unit/features/test_features.py
@@ -1,7 +1,9 @@
 import numpy as np
 import pytest
 from numpy.testing import assert_array_equal
+from torch.utils.data import RandomSampler, SequentialSampler
 
+from openadmet.models.features.chemprop import ChemPropFeaturizer
 from openadmet.models.features.combine import FeatureConcatenator
 from openadmet.models.features.molfeat_fingerprint import FingerprintFeaturizer
 from openadmet.models.features.molfeat_properties import DescriptorFeaturizer
@@ -192,3 +194,67 @@ def test_pairwise_featurizer(smiles):
     expected_y = np.array([0.0, -1.0, 0.0, 1.0, 0.0, 1.0, 0.0, -1.0, 0.0])
     assert [dataset[i][2] for i in range(9)] == pytest.approx(expected_y)
     assert scaler is None  # No scaling applied in FingerprintFeaturizer
+
+
+# 3 SMILES at batch_size 2 leaves a size-1 final batch (len % batch_size == 1),
+# the condition that triggers the batch-norm drop_last guard.
+def test_chemprop_eval_loader_preserves_order_and_length(smiles):
+    """Regression (#383, #517): an eval loader must not shuffle or drop, even when shuffle=True."""
+    featurizer = ChemPropFeaturizer(shuffle=True, batch_size=2, n_jobs=0)
+
+    dataloader, _, _, dataset = featurizer.featurize(
+        smiles, y=np.array([1.0, 2.0, 3.0])
+    )
+
+    assert isinstance(dataloader.sampler, SequentialSampler)
+    assert dataloader.drop_last is False
+    assert sum(batch.Y.shape[0] for batch in dataloader) == len(dataset)
+
+
+def test_chemprop_train_loader_shuffles_and_drops_singleton(smiles):
+    """A training loader honors shuffle=True and drops a size-1 final batch for batch norm."""
+    featurizer = ChemPropFeaturizer(shuffle=True, batch_size=2, n_jobs=0)
+
+    dataloader, _, _, _ = featurizer.featurize(
+        smiles, y=np.array([1.0, 2.0, 3.0]), train=True
+    )
+
+    assert isinstance(dataloader.sampler, RandomSampler)
+    assert dataloader.drop_last is True
+
+
+def test_pairwise_eval_loader_preserves_order_and_length(smiles):
+    """Regression (#383, #517): an eval loader must not shuffle or drop, even when shuffle=True."""
+    featurizer = PairwiseFeaturizer(
+        featurizer={"FingerprintFeaturizer": {"fp_type": "ecfp", "n_jobs": 1}},
+        how_to_pair="full",
+        batch_size=2,  # 9 pairs % 2 == 1 -> size-1 final batch
+        shuffle=True,
+        n_jobs=0,
+    )
+
+    dataloader, _, _, dataset = featurizer.featurize(
+        smiles, y=np.array([1.0, 2.0, 1.0])
+    )
+
+    assert isinstance(dataloader.sampler, SequentialSampler)
+    assert dataloader.drop_last is False
+    assert sum(len(batch[2]) for batch in dataloader) == len(dataset)
+
+
+def test_pairwise_train_loader_shuffles_and_drops_singleton(smiles):
+    """A training loader honors shuffle=True and drops a size-1 final batch for batch norm."""
+    featurizer = PairwiseFeaturizer(
+        featurizer={"FingerprintFeaturizer": {"fp_type": "ecfp", "n_jobs": 1}},
+        how_to_pair="full",
+        batch_size=2,  # 9 pairs % 2 == 1 -> size-1 final batch
+        shuffle=True,
+        n_jobs=0,
+    )
+
+    dataloader, _, _, _ = featurizer.featurize(
+        smiles, y=np.array([1.0, 2.0, 1.0]), train=True
+    )
+
+    assert isinstance(dataloader.sampler, RandomSampler)
+    assert dataloader.drop_last is True


### PR DESCRIPTION
## What

Makes `shuffle` and `drop_last` **training-only** in the deep-learning featurizers, so validation, test, cross-validation, and inference loaders always preserve input order and length.

Implements the plan in #571 and closes the two underlying bugs:
- Closes #383 — `shuffle=True` permuted eval loaders, silently corrupting metrics (predictions are concatenated in loader order and paired positionally with `y_true`).
- Closes #517 — the size-1 `drop_last` guard dropped a test/inference row, misaligning the whole vector or crashing.

## How

- Add a `train: bool = False` parameter to the `DeepLearningFeaturizer.featurize` contract, honored by `ChemPropFeaturizer` and `PairwiseFeaturizer`.
- `train=True` → `shuffle=self.shuffle` and the batch-norm `drop_last` guard apply. `train=False` (default) → `shuffle=False`, `drop_last=False`, unconditionally.
- Thread `train=True` through the three training call sites: the deep-learning workflow train loader, the ensemble bootstrap train loader (`anvil/workflow.py`), and the CV fold train loader (`eval/cross_validation.py`). All eval/inference loaders keep the safe default.
- Correct the inverted sampler guard in `_vendor_build_dataloader` (`if sampler is not None` → `if sampler is None`), which made the class-balance and seeded-sampler paths unreachable. Inert for the current workflow path (no `seed`/`class_balance` passed), so no behavior change there.
- The inference point-patch (`feat.shuffle = False`) is retained as documented defense-in-depth.

## Contract

| Loader | shuffle | drop_last |
|---|---|---|
| train (`train=True`) | follows `feat.shuffle` | drops a size-1 final batch (batch-norm guard) |
| val / test / CV-val / inference (`train=False`) | forced off | forced off (every row returned) |

## Tests

Added four regression tests in `tests/unit/features/test_features.py` (two per featurizer), asserting on the real `DataLoader`:
- eval loader (`train=False`) with `shuffle=True` → `SequentialSampler`, `drop_last is False`, all rows returned (fails on old code: #383 + #517).
- train loader (`train=True`) → `RandomSampler`, drops the size-1 final batch.

Full unit suite for `features`, `inference`, `anvil`, and `eval` passes; pre-commit clean.

## Quality Assurance & AI Policy
To maintain project quality and respect maintainer bandwidth, please confirm the following:

- [x] **Manual Verification:** I have manually reviewed and tested the code in this PR.
- [x] **AI-Assisted Content:** If AI tools were used (e.g., Copilot, ChatGPT), I have personally verified the logic, edge cases, and compliance with the existing codebase. I confirm the code is not a "blind" AI generation.
- [x] **Minimal Review:** I believe this PR is in a state that requires minimal intervention or correction from maintainers.
- [x] **Scoped Change:** This PR addresses a single, well-scoped issue rather than multiple unrelated changes.

## Status
- [x] Ready to go (Checking this signals to maintainers that the PR is ready for final review)

## Developers Certificate of Origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenADMET/openadmet_toolkit/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.

---
**Note to Contributors:** We reserve the right to close PRs without review if they appear to lack human validation or do not meet the quality standards described in our `CONTRIBUTING.md`.

