### PR TITLE
Set persistent_workers=True in ChemProp DataLoader to prevent fd exhaustion

### DIFF
--- a/openadmet/models/features/chemprop.py
+++ b/openadmet/models/features/chemprop.py
@@ -89,6 +89,9 @@ def _vendor_build_dataloader(
         num_workers=num_workers,
         collate_fn=collate_fn,
         drop_last=drop_last,
+        # keep workers alive across epochs to avoid re-spawning pipes each epoch,
+        # which exhausts file descriptors on long runs
+        persistent_workers=num_workers > 0,
         **kwargs,
     )
 


### PR DESCRIPTION
## Description

PyTorch's multiprocessing DataLoader spawns `num_workers` worker processes at the start of every epoch and tears them down at the end. Each spawn round-trips through `os.pipe()`, consuming file descriptors. `ChemPropFeaturizer` defaults to `n_jobs=4`, so four worker processes (and their pipes) are created and destroyed each epoch. macOS is slow to reclaim those file descriptors, and the per-process OS limit (~256) is exhausted around epoch 17, producing `OSError: [Errno 24] Too many open files`.

The fix is a one-line addition to `_vendor_build_dataloader` in `openadmet/models/features/chemprop.py`: pass `persistent_workers=num_workers > 0` to the `DataLoader` constructor. This keeps the worker pool alive across epochs, so the file-descriptor count stays flat for the duration of training regardless of how many epochs are run.

## Quality Assurance & AI Policy
To maintain project quality and respect maintainer bandwidth, please confirm the following:

- [x] **Manual Verification:** I have manually reviewed and tested the code in this PR.
- [x] **AI-Assisted Content:** If AI tools were used (e.g., Copilot, ChatGPT), I have personally verified the logic, edge cases, and compliance with the existing codebase. I confirm the code is not a "blind" AI generation.
- [x] **Minimal Review:** I believe this PR is in a state that requires minimal intervention or correction from maintainers.
- [x] **Scoped Change:** This PR addresses a single, well-scoped issue rather than multiple unrelated changes.

## Status
- [x] Ready to go (Checking this signals to maintainers that the PR is ready for final review)

## Developers Certificate of Origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenADMET/openadmet_toolkit/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.

---
**Note to Contributors:** We reserve the right to close PRs without review if they appear to lack human validation or do not meet the quality standards described in our `CONTRIBUTING.md`.