### PR TITLE
Migrate ReadTheDocs conda tool from mambaforge to miniforge3

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,7 +18,7 @@ build:
   os: ubuntu-lts-latest
   tools:
     # python: "miniconda3-4.7"
-    python: "mambaforge-latest"
+    python: "miniforge3-latest"
 
 # Optionally set the version of Python and requirements required to build your docs
 python:


### PR DESCRIPTION
## Description

Fixes the ReadTheDocs build failure described in #582.

`ubuntu-lts-latest` recently moved from Ubuntu 24.04 to 26.04, and the pinned `mambaforge-latest` conda tool (aliases to `mambaforge-23.11.0-0`) fails to install on the new image, breaking docs CI for every PR. `mambaforge` is deprecated by ReadTheDocs regardless of this, in favor of `miniforge3-*`.

This implements one of the resolutions proposed in #582: migrate `build.tools.python` from `mambaforge-latest` to `miniforge3-latest`, and keep `build.os: ubuntu-lts-latest` as is (fixing any future incompatibility as it arises rather than pinning ahead of time).

Single-line change to `.readthedocs.yml`.

## Quality Assurance & AI Policy
To maintain project quality and respect maintainer bandwidth, please confirm the following:

- [x] **Manual Verification:** I have manually reviewed and tested the code in this PR.
- [x] **AI-Assisted Content:** If AI tools were used (e.g., Copilot, ChatGPT), I have personally verified the logic, edge cases, and compliance with the existing codebase. I confirm the code is not a "blind" AI generation.
- [x] **Minimal Review:** I believe this PR is in a state that requires minimal intervention or correction from maintainers.
- [x] **Scoped Change:** This PR addresses a single, well-scoped issue rather than multiple unrelated changes.

## Status
- [x] Ready to go (Checking this signals to maintainers that the PR is ready for final review)

## Developers Certificate of Origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenADMET/openadmet_toolkit/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
